### PR TITLE
Update fable-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-es2015": "6.24.1",
     "concurrently": "3.5.0",
-    "fable-loader": "1.1.2",
+    "fable-loader": "1.1.3",
     "fable-utils": "1.0.6",
     "webpack": "3.6.0",
     "webpack-dev-server": "2.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,9 +1425,9 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
 
-fable-loader@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fable-loader/-/fable-loader-1.1.2.tgz#b5c435230858158586aedc55449efcae67aed767"
+fable-loader@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fable-loader/-/fable-loader-1.1.3.tgz#01d8b2233ae6ae67f964d19082ff5b7c981f8a33"
   dependencies:
     fable-utils "^1.0.4"
 


### PR DESCRIPTION
Latest Fable was creating issues with the fable-loader as it added a dependency to all project files to the entry .fsrproj.