### PR TITLE
Placed `withDebugger` in the correct position

### DIFF
--- a/src/Client/App.fs
+++ b/src/Client/App.fs
@@ -187,8 +187,10 @@ Program.mkProgram init update view
 |> Program.toNavigable (parseHash pageParser) urlUpdate
 #if DEBUG
 |> Program.withConsoleTrace
-|> Program.withDebugger
 |> Program.withHMR
 #endif
 |> Program.withReact "elmish-app"
+#if DEBUG
+|> Program.withDebugger
+#endif
 |> Program.run


### PR DESCRIPTION
`withDebugger` must be the last command in the Elmish program chain. With this fix the time-travelling debugger tools work correctly.