### PR TITLE
Removed usage of lazyView2

### DIFF
--- a/src/Client/App.fs
+++ b/src/Client/App.fs
@@ -168,13 +168,13 @@ let viewPage model dispatch =
     | Page.WishList ->
         match model.SubModel with
         | WishListModel m ->
-            [ div [ ] [ lazyView2 WishList.view m dispatch ]]
+            [ div [ ] [ WishList.view m dispatch ]]
         | _ -> [ ]
 
 /// Constructs the view for the application given the model.
 let view model dispatch =
   div []
-    [ lazyView2 Menu.view model.Menu dispatch
+    [ Menu.view model.Menu dispatch
       hr []
       div [ centerStyle "column" ] (viewPage model dispatch)
     ]


### PR DESCRIPTION
This change is intended for better first time experience with HMR. Currently lazy views are not invalidated and reloaded with HMR unless you make changes to the state of the component or change the model of the component. This makes the first time experience with HMR really confusing.