### PR TITLE
use phantomjs-prebuilt

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -161,7 +161,7 @@ Target "BuildClient" (fun _ ->
 
 Target "RenameDrivers" (fun _ ->
     if not isWindows then
-        run npmTool "install phantomjs" ""
+        run npmTool "install phantomjs-prebuilt" ""
     try
         if isMacOS && not <| File.Exists "test/UITests/bin/Debug/net461/chromedriver" then
             Fake.FileHelper.Rename "test/UITests/bin/Debug/net461/chromedriver" "test/UITests/bin/Debug/net461/chromedriver_macOS"

--- a/test/UITests/Runner.fs
+++ b/test/UITests/Runner.fs
@@ -29,7 +29,7 @@ let startBrowser() =
     if isWindows then
         canopy.configuration.phantomJSDir <- Path.Combine(rootDir.FullName,"packages/uitests/PhantomJS/tools/phantomjs")
     else
-        canopy.configuration.phantomJSDir <- Path.Combine(rootDir.FullName,"node_modules/phantomjs/bin")
+        canopy.configuration.phantomJSDir <- Path.Combine(rootDir.FullName,"node_modules/phantomjs-prebuilt/bin")
 
 
     start phantomJS //Use 'start chrome' if you want to see your tests in the browser


### PR DESCRIPTION
Looks like `phantomjs` is [deprecated](https://travis-ci.org/SAFE-Stack/SAFE-BookStore/builds/296451800#L4191):
`npm WARN deprecated phantomjs@2.1.7: Package renamed to phantomjs-prebuilt. Please update 'phantomjs' package references to 'phantomjs-prebuilt'`

This PR updates to the recommended `phantomjs-prebuilt` package.