### PR TITLE
Removed custom JSON handler

### DIFF
--- a/src/Server/FableJson.fs
+++ b/src/Server/FableJson.fs
@@ -2,8 +2,6 @@
 module ServerCode.FableJson
 
 open Newtonsoft.Json
-open Giraffe
-open Microsoft.AspNetCore.Http
 
 // The Fable.JsonConverter serializes F# types so they can be deserialized on the
 // client side by Fable into full type instances, see http://fable.io/blog/Introducing-0-7.html#JSON-Serialization
@@ -16,14 +14,3 @@ let toJson value =
 
 let ofJson<'a> (json:string) : 'a =
     JsonConvert.DeserializeObject<'a>(json, [|jsonConverter|])
-
-let serialize x =
-    setStatusCode 200
-      >=> setHttpHeader "Content-Type" "application/json"
-      >=> setBodyFromString (toJson x)
-
-
-let getJsonFromCtx<'a> (ctx:HttpContext) = task {
-    let! t = ctx.ReadBodyFromRequestAsync()
-    return ofJson<'a> t
-}

--- a/src/Server/Program.fs
+++ b/src/Server/Program.fs
@@ -3,23 +3,25 @@ module ServerCode.Program
 
 open System
 open System.IO
+open Microsoft.AspNetCore
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.Logging
+open Microsoft.Extensions.DependencyInjection
+open Newtonsoft.Json
 open Giraffe
-open Microsoft.AspNetCore
-open ServerErrors
+open Giraffe.Serialization.Json
+open Giraffe.HttpStatusCodeHandlers.ServerErrors
 
-let GetEnvVar var = 
+let GetEnvVar var =
     match Environment.GetEnvironmentVariable(var) with
     | null -> None
     | value -> Some value
 
-let getPortsOrDefault defaultVal = 
+let getPortsOrDefault defaultVal =
     match Environment.GetEnvironmentVariable("SUAVE_FABLE_PORT") with
     | null -> defaultVal
     | value -> value |> uint16
-
 
 let errorHandler (ex : Exception) (logger : ILogger) =
     logger.LogError(EventId(), ex, "An unhandled exception has occurred while executing the request.")
@@ -29,13 +31,22 @@ let configureApp db root (app : IApplicationBuilder) =
     app.UseGiraffeErrorHandler(errorHandler)
        .UseStaticFiles()
        .UseGiraffe (WebServer.webApp db root)
-       
+
+let configureServices (services : IServiceCollection) =
+    // Add default Giraffe dependencies
+    services.AddGiraffe() |> ignore
+
+    // Configure JsonSerializer to use Fable.JsonConverter
+    let fableJsonSettings = JsonSerializerSettings()
+    fableJsonSettings.Converters.Add(Fable.JsonConverter())
+
+    services.AddSingleton<IJsonSerializer>(
+        NewtonsoftJsonSerializer(fableJsonSettings)) |> ignore
+
 let configureLogging (loggerBuilder : ILoggingBuilder) =
     loggerBuilder.AddFilter(fun lvl -> lvl.Equals LogLevel.Error)
                  .AddConsole()
                  .AddDebug() |> ignore
-
-
 
 [<EntryPoint>]
 let main args =
@@ -44,14 +55,14 @@ let main args =
         let clientPath =
             match args with
             | clientPath:: _  when Directory.Exists clientPath -> clientPath
-            | _ -> 
+            | _ ->
                 // did we start from server folder?
                 let devPath = Path.Combine("..","Client")
-                if Directory.Exists devPath then devPath 
+                if Directory.Exists devPath then devPath
                 else
                     // maybe we are in root of project?
                     let devPath = Path.Combine("src","Client")
-                    if Directory.Exists devPath then devPath 
+                    if Directory.Exists devPath then devPath
                     else @"./client"
             |> Path.GetFullPath
 
@@ -65,12 +76,13 @@ let main args =
             |> Option.defaultValue Database.DatabaseType.FileSystem
 
         let port = getPortsOrDefault 8085us
-        
+
         WebHost
             .CreateDefaultBuilder()
             .UseWebRoot(clientPath)
             .UseContentRoot(clientPath)
             .ConfigureLogging(configureLogging)
+            .ConfigureServices(configureServices)
             .Configure(Action<IApplicationBuilder> (configureApp database clientPath))
             .UseUrls("http://0.0.0.0:" + port.ToString() + "/")
             .Build()


### PR DESCRIPTION
Configured Giraffe's JSON serializer to use the FableConverter so that all JSON (de-)serialize methods use the Fable settings. As a result I could remove the custom JSON handlers for binding a model and writing a response.