### PR TITLE
Little Refactor

### DIFF
--- a/src/Server/Server.fsproj
+++ b/src/Server/Server.fsproj
@@ -4,10 +4,10 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="ServerTypes.fs" />
-    <Compile Include="JsonWebToken.fs" />
     <Compile Include="Shared/Domain.fs" />
     <Compile Include="Shared/ServerUrls.fs" />
+    <Compile Include="ServerTypes.fs" />
+    <Compile Include="JsonWebToken.fs" />
     <Compile Include="FableJson.fs" />
     <Compile Include="Auth.fs" />
     <Compile Include="WishList.fs" />

--- a/src/Server/Server.fsproj
+++ b/src/Server/Server.fsproj
@@ -4,10 +4,10 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Shared/Domain.fs" />
-    <Compile Include="Shared/ServerUrls.fs" />
     <Compile Include="ServerTypes.fs" />
     <Compile Include="JsonWebToken.fs" />
+    <Compile Include="Shared/Domain.fs" />
+    <Compile Include="Shared/ServerUrls.fs" />
     <Compile Include="FableJson.fs" />
     <Compile Include="Auth.fs" />
     <Compile Include="WishList.fs" />

--- a/src/Server/ServerTypes.fs
+++ b/src/Server/ServerTypes.fs
@@ -1,8 +1,6 @@
-/// Module of server domain types. 
+/// Module of server domain types.
 module ServerCode.ServerTypes
 
 /// Represents the rights available for a request
-type UserRights = 
+type UserRights =
    { UserName : string }
-
-    

--- a/src/Server/Shared/Domain.fs
+++ b/src/Server/Shared/Domain.fs
@@ -1,41 +1,54 @@
 /// Domain model shared between client and server.
 namespace ServerCode.Domain
-   
+
 open System
+open ServerCode
 
 // Json web token type.
 type JWT = string
 
 // Login credentials.
-type Login = 
-    { UserName : string
-      Password : string
+type Login =
+    { UserName   : string
+      Password   : string
       PasswordId : Guid }
 
-type UserData = 
-  { UserName : string 
-    Token : JWT }
+    member this.IsValid() =
+        not ((this.UserName <> "test"  || this.Password <> "test") &&
+             (this.UserName <> "test2" || this.Password <> "test2"))
 
+type UserData =
+  { UserName : string
+    Token    : JWT }
+
+  static member FromLogin (login : Login) =
+    {
+        UserName = login.UserName
+        Token    =
+            JsonWebToken.encode (
+                { UserName = login.UserName } : ServerTypes.UserRights
+            )
+    }
 
 /// The data for each book in /api/wishlist
-type Book = 
+type Book =
     { Title: string
       Authors: string
       Link: string }
 
-    static member empty = 
+    static member empty =
         { Title = ""
           Authors = ""
           Link = "" }
 
 /// The logical representation of the data for /api/wishlist
-type WishList = 
+type WishList =
     { UserName : string
       Books : Book list }
 
     // Create a new WishList.  This is supported in client code too,
     // thanks to the magic of https://www.nuget.org/packages/Fable.JsonConverter
-    static member New userName = 
+    static member New userName =
         { UserName = userName
           Books = [] }
 

--- a/src/Server/Shared/Domain.fs
+++ b/src/Server/Shared/Domain.fs
@@ -2,7 +2,6 @@
 namespace ServerCode.Domain
 
 open System
-open ServerCode
 
 // Json web token type.
 type JWT = string
@@ -20,15 +19,6 @@ type Login =
 type UserData =
   { UserName : string
     Token    : JWT }
-
-  static member FromLogin (login : Login) =
-    {
-        UserName = login.UserName
-        Token    =
-            JsonWebToken.encode (
-                { UserName = login.UserName } : ServerTypes.UserRights
-            )
-    }
 
 /// The data for each book in /api/wishlist
 type Book =

--- a/src/Server/WebServer.fs
+++ b/src/Server/WebServer.fs
@@ -9,7 +9,7 @@ open RequestErrors
 /// Start the web server and connect to database
 let webApp databaseType root =
     let startupTime = System.DateTime.UtcNow
-    
+
     let db = Database.getDatabase databaseType startupTime
 
     let notfound = NOT_FOUND "Page not found"
@@ -17,12 +17,12 @@ let webApp databaseType root =
     router notfound [
         GET [
             route "/" (htmlFile (System.IO.Path.Combine(root,"index.html")))
-            route ServerUrls.WishList (WishList.getWishList db.LoadWishList)
+            route ServerUrls.WishList => Auth.requiresJwtToken (WishList.getWishList db.LoadWishList)
             route ServerUrls.ResetTime (WishList.getResetTime db.GetLastResetTime)
         ]
 
         POST [
             route ServerUrls.Login Auth.login
-            route ServerUrls.WishList (WishList.postWishList db.SaveWishList)
+            route ServerUrls.WishList => Auth.requiresJwtToken (WishList.postWishList db.SaveWishList)
         ]
     ]

--- a/src/Server/WishList.fs
+++ b/src/Server/WishList.fs
@@ -1,47 +1,42 @@
 /// Wish list API web parts and data access functions.
 module ServerCode.WishList
 
-open Giraffe
-open RequestErrors
-open ServerErrors
-open ServerCode.Domain
-open Microsoft.AspNetCore.Http
-open Microsoft.Extensions.Logging
 open System.Threading.Tasks
+open Microsoft.AspNetCore.Http
+open Giraffe
+open ServerCode.Domain
+open ServerTypes
 
 /// Handle the GET on /api/wishlist
-let getWishList (getWishListFromDB: string -> Task<WishList>) next (ctx: HttpContext) =
-    Auth.useToken next ctx (fun token -> task {
-        try
+let getWishList (getWishListFromDB : string -> Task<WishList>) (token : UserRights) : HttpHandler =
+     fun (next : HttpFunc) (ctx : HttpContext) ->
+        task {
             let! wishList = getWishListFromDB token.UserName
             return! ctx.WriteJsonAsync wishList
-        with exn ->
-            let msg = "Database not available"
-            let logger = ctx.GetLogger "wishlist"
-            logger.LogError (EventId(), exn, msg)
-            return! SERVICE_UNAVAILABLE "Database not available" next ctx
-    })
+        }
+
+let private invalidWishList =
+    RequestErrors.BAD_REQUEST "WishList is not valid"
+
+let inline private forbiddenWishList username =
+    sprintf "WishList is not matching user %s" username
+    |> RequestErrors.FORBIDDEN
 
 /// Handle the POST on /api/wishlist
-let postWishList (saveWishListToDB: WishList -> Task<unit>) next (ctx: HttpContext) =
-    Auth.useToken next ctx (fun token -> task {
-        try
+let postWishList (saveWishListToDB: WishList -> Task<unit>) (token : UserRights) : HttpHandler =
+    fun (next : HttpFunc) (ctx : HttpContext) ->
+        task {
             let! wishList = ctx.BindJsonAsync<Domain.WishList>()
 
-            if token.UserName <> wishList.UserName then
-                return! FORBIDDEN (sprintf "WishList is not matching user %s" token.UserName) next ctx
-            else
-                if Validation.verifyWishList wishList then
+            match token.UserName.Equals wishList.UserName with
+            | true ->
+                match Validation.verifyWishList wishList with
+                | true ->
                     do! saveWishListToDB wishList
                     return! ctx.WriteJsonAsync wishList
-                else
-                    return! BAD_REQUEST "WishList is not valid" next ctx
-        with exn ->
-            let msg = "Database not available"
-            let logger = ctx.GetLogger "wishlist"
-            logger.LogError (EventId(), exn, msg)
-            return! SERVICE_UNAVAILABLE "Database not available" next ctx
-    })
+                | false -> return! forbiddenWishList token.UserName next ctx
+            | false     -> return! invalidWishList next ctx
+        }
 
 /// Retrieve the last time the wish list was reset.
 let getResetTime (getLastResetTime: unit -> Task<System.DateTime>) : HttpHandler =


### PR DESCRIPTION
Simplified the Auth and WishList modules.

- Removed try-with in WishList functions by moving the error code to the error handler
- Removed try-with from login and return an error response straight away without throwing an exception first
- Changed the Auth useToken to requiresToken which is a handler now which validates the token and then passes the token to another http handler. This makes it possible to chain `Auth.requiresJwtToken` in the router so it is explicitly visible to any user at first sight which routes require authentication.

I have made a few changes which I think make the code a bit tidier and simpler, but it is very subjective, so please reject this PR or feel free to modify if you don't like it!