### PR TITLE
Reorder parameters to fable webpack-dev-server

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -205,7 +205,7 @@ Target "Run" (fun _ ->
 
         if result <> 0 then failwith "Website shut down." }
 
-    let fablewatch = async { runDotnet clientPath "fable --port free webpack-dev-server" }
+    let fablewatch = async { runDotnet clientPath "fable webpack-dev-server --port free" }
     let openBrowser = async {
         System.Threading.Thread.Sleep(5000)
         Diagnostics.Process.Start("http://"+ ipAddress + sprintf ":%d" port) |> ignore }


### PR DESCRIPTION
When I execute `build run` I currently get an error and webpack isn't run:

```
dotnet fable --port free webpack-dev-server
dotnet watch msbuild /t:TestAndRun /p:DotNetHost=dotnet
Unrecognized command: --port. Use `dotnet fable --help` to see available options.
```
If I reorder the parameters to match the equivalent command in package.json it runs webpack as expected.