### PR TITLE
[WIP] Fake 5 Migration

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,9 +1,21 @@
 @echo off
+setlocal
 cls
+
+pushd %~dp0
 
 .paket\paket.exe restore
 if errorlevel 1 (
   exit /b %errorlevel%
 )
 
-packages\build\FAKE\tools\FAKE.exe build.fsx %*
+if not exist ".fake\fake.exe" (
+  dotnet tool install fake-cli --tool-path .\.fake
+)
+
+.fake\fake.exe build %*
+if errorlevel 1 (
+  exit /b %errorlevel%
+)
+
+popd

--- a/build.fsx
+++ b/build.fsx
@@ -1,16 +1,22 @@
 // --------------------------------------------------------------------------------------
 // FAKE build script
 // --------------------------------------------------------------------------------------
+#r @"paket: groupref Build //"
+#load "./.fake/build.fsx/intellisense.fsx"
 
-#r @"packages/build/FAKE/tools/FakeLib.dll"
+#if !FAKE
+  #r "netstandard" // Temp fix for https://github.com/fsharp/FAKE/issues/1985
+#endif
 
-open Fake
-open Fake.Git
-open Fake.AssemblyInfoFile
-open Fake.ReleaseNotesHelper
+open Fake.Core
+open Fake.DotNet
+open Fake.DotNet.Testing
+open Fake.IO
+open Fake.IO.FileSystemOperators
+open Fake.IO.Globbing.Operators
+open Fake.Tools
 open System
 open System.IO
-open Fake.Testing.Expecto
 
 let project = "Suave/Fable sample"
 
@@ -20,112 +26,112 @@ let description = summary
 
 let configuration = "Release"
 
-let clientPath = "./src/Client" |> FullName
+let clientPath = "./src/Client" |> Path.getFullName
 
-let serverPath = "./src/Server/" |> FullName
+let serverPath = "./src/Server/" |> Path.getFullName
 
-let serverTestsPath = "./test/ServerTests" |> FullName
-let clientTestsPath = "./test/UITests" |> FullName
+let serverTestsPath = "./test/ServerTests" |> Path.getFullName
+let clientTestsPath = "./test/UITests" |> Path.getFullName
 
-let dotnetcliVersion = DotNetCli.GetDotNetSDKVersionFromGlobalJson()
-let mutable dotnetExePath = "dotnet"
+let dotnetcliVersion = DotNet.getSDKVersionFromGlobalJson()
+let dotnetExePath = "dotnet"
 
 let deployDir = "./deploy"
 
 // Pattern specifying assemblies to be tested using expecto
 let clientTestExecutables = "test/UITests/**/bin/**/*Tests*.exe"
 
-let dockerUser = getBuildParam "DockerUser"
-let dockerPassword = getBuildParam "DockerPassword"
-let dockerLoginServer = getBuildParam "DockerLoginServer"
-let dockerImageName = getBuildParam "DockerImageName"
+let dockerUser = Environment.environVar "DockerUser"
+let dockerPassword = Environment.environVar "DockerPassword"
+let dockerLoginServer = Environment.environVar "DockerLoginServer"
+let dockerImageName = Environment.environVar "DockerImageName"
 
 // --------------------------------------------------------------------------------------
 // END TODO: The rest of the file includes standard build steps
 // --------------------------------------------------------------------------------------
 
 let run' timeout cmd args dir =
-    if execProcess (fun info ->
-        info.FileName <- cmd
-        if not (String.IsNullOrWhiteSpace dir) then
-            info.WorkingDirectory <- dir
-        info.Arguments <- args
-    ) timeout |> not then
-        failwithf "Error while running '%s' with args: %s" cmd args
+    let result =
+        Process.execSimple (fun info ->
+            { info with
+                FileName = cmd
+                Arguments = args
+                WorkingDirectory = if String.isNullOrWhiteSpace dir then info.WorkingDirectory else dir }
+        ) timeout
+    if result <> 0 then failwithf "Error while running '%s' with args: %s" cmd args
 
 let run = run' System.TimeSpan.MaxValue
 
 let runDotnet workingDir args =
     let result =
-        ExecProcess (fun info ->
-            info.FileName <- dotnetExePath
-            info.WorkingDirectory <- workingDir
-            info.Arguments <- args) TimeSpan.MaxValue
+        Process.execSimple (fun info ->
+            { info with
+                FileName = dotnetExePath
+                WorkingDirectory = workingDir
+                Arguments = args }
+        ) TimeSpan.MaxValue
     if result <> 0 then failwithf "dotnet %s failed" args
 
 let platformTool tool winTool =
-    let tool = if isUnix then tool else winTool
+    let tool = if Environment.isUnix then tool else winTool
     tool
-    |> ProcessHelper.tryFindFileOnPath
+    |> Process.tryFindFileOnPath
     |> function Some t -> t | _ -> failwithf "%s not found" tool
 
 let nodeTool = platformTool "node" "node.exe"
 let npmTool = platformTool "npm" "npm.cmd"
 let yarnTool = platformTool "yarn" "yarn.cmd"
 
-do if not isWindows then
+if not <| Environment.isWindows then
     // We have to set the FrameworkPathOverride so that dotnet sdk invocations know
     // where to look for full-framework base class libraries
     let mono = platformTool "mono" "mono"
     let frameworkPath = IO.Path.GetDirectoryName(mono) </> ".." </> "lib" </> "mono" </> "4.5"
-    setEnvironVar "FrameworkPathOverride" frameworkPath
+    Environment.setEnvironVar "FrameworkPathOverride" frameworkPath
 
 
 // Read additional information from the release notes document
 let releaseNotes = File.ReadAllLines "RELEASE_NOTES.md"
 
-let releaseNotesData =
-    releaseNotes
-    |> parseAllReleaseNotes
-
-let release = List.head releaseNotesData
+let release = ReleaseNotes.parse releaseNotes
 
 // --------------------------------------------------------------------------------------
 // Clean build results
-
-Target "Clean" (fun _ ->
-    !!"src/**/bin"
+Target.create "Clean" (fun _ ->
+    !! "src/**/bin"
     ++ "test/**/bin"
-    |> CleanDirs
+    |> Shell.cleanDirs
 
     !! "src/**/obj/*.nuspec"
     ++ "test/**/obj/*.nuspec"
-    |> DeleteFiles
+    |> Seq.iter Shell.rm
 
-    CleanDirs ["bin"; "temp"; "docs/output"; deployDir; Path.Combine(clientPath,"public/bundle")]
+    Shell.cleanDirs ["bin"; "temp"; "docs/output"; deployDir; Path.Combine(clientPath,"public/bundle")]
 )
 
-Target "InstallDotNetCore" (fun _ ->
-    dotnetExePath <- DotNetCli.InstallDotNetSDK dotnetcliVersion
+Target.create "InstallDotNetCore" (fun _ ->
+    let setParams (options : DotNet.CliInstallOptions) =
+        { options with
+            Version = DotNet.Version dotnetcliVersion }
+
+    DotNet.install setParams |> ignore
 )
 
 // --------------------------------------------------------------------------------------
 // Build library & test project
-
-
-Target "BuildServer" (fun _ ->
+Target.create "BuildServer" (fun _ ->
     runDotnet serverPath "build"
 )
 
-Target "BuildClientTests" (fun _ ->
+Target.create "BuildClientTests" (fun _ ->
     runDotnet clientTestsPath "build"
 )
 
-Target "BuildServerTests" (fun _ ->
+Target.create "BuildServerTests" (fun _ ->
     runDotnet serverTestsPath "build"
 )
 
-Target "InstallClient" (fun _ ->
+Target.create "InstallClient" (fun _ ->
     printfn "Node version:"
     run nodeTool "--version" __SOURCE_DIRECTORY__
     printfn "Yarn version:"
@@ -133,17 +139,17 @@ Target "InstallClient" (fun _ ->
     run yarnTool "install --frozen-lockfile" __SOURCE_DIRECTORY__
 )
 
-Target "BuildClient" (fun _ ->
+Target.create "BuildClient" (fun _ ->
     runDotnet clientPath "restore"
     runDotnet clientPath "fable webpack --port free -- -p --mode production"
 )
 
-Target "RunServerTests" (fun _ ->
+Target.create "RunServerTests" (fun _ ->
     runDotnet serverTestsPath "run"
 )
 
-Target "RunClientTests" (fun _ ->
-    ActivateFinalTarget "KillProcess"
+Target.create "RunClientTests" (fun _ ->
+    Target.activateFinal "KillProcess"
 
     let serverProcess =
         let info = System.Diagnostics.ProcessStartInfo()
@@ -156,7 +162,7 @@ Target "RunClientTests" (fun _ ->
     System.Threading.Thread.Sleep 15000 |> ignore  // give server some time to start
 
     !! clientTestExecutables
-    |> Expecto (fun p -> { p with Parallel = false } )
+    |> Expecto.run (fun p -> { p with Parallel = false } )
     |> ignore
 
     serverProcess.Kill()
@@ -164,27 +170,27 @@ Target "RunClientTests" (fun _ ->
 
 // --------------------------------------------------------------------------------------
 // Run the Website
-
 let ipAddress = "localhost"
 let port = 8080
 let serverPort = 8085
 
-FinalTarget "KillProcess" (fun _ ->
-    killProcess "dotnet"
-    killProcess "dotnet.exe"
+Target.createFinal "KillProcess" (fun _ ->
+    Process.killAllByName "dotnet"
+    Process.killAllByName "dotnet.exe"
 )
 
-
-Target "Run" (fun _ ->
+Target.create "Run" (fun _ ->
     runDotnet clientPath "restore"
     runDotnet serverTestsPath "restore"
 
     let unitTestsWatch = async {
         let result =
-            ExecProcess (fun info ->
-                info.FileName <- dotnetExePath
-                info.WorkingDirectory <- serverTestsPath
-                info.Arguments <- sprintf "watch msbuild /t:TestAndRun /p:DotNetHost=%s" dotnetExePath) TimeSpan.MaxValue
+            Process.execSimple (fun info ->
+                { info with
+                    FileName = dotnetExePath
+                    WorkingDirectory = serverTestsPath
+                    Arguments = sprintf "watch msbuild /t:TestAndRun /p:DotNetHost=%s" dotnetExePath }
+            ) TimeSpan.MaxValue
 
         if result <> 0 then failwith "Website shut down." }
 
@@ -198,17 +204,18 @@ Target "Run" (fun _ ->
     |> ignore
 )
 
-
-Target "RunSSR" (fun _ ->
+Target.create "RunSSR" (fun _ ->
     runDotnet clientPath "restore"
     runDotnet serverTestsPath "restore"
 
     let unitTestsWatch = async {
         let result =
-            ExecProcess (fun info ->
-                info.FileName <- dotnetExePath
-                info.WorkingDirectory <- serverTestsPath
-                info.Arguments <- sprintf "watch msbuild /t:TestAndRun /p:DotNetHost=%s /p:DebugSSR=true" dotnetExePath) TimeSpan.MaxValue
+            Process.execSimple (fun info ->
+                { info with
+                    FileName = dotnetExePath
+                    WorkingDirectory = serverTestsPath
+                    Arguments = sprintf "watch msbuild /t:TestAndRun /p:DotNetHost=%s /p:DebugSSR=true" dotnetExePath }
+            ) TimeSpan.MaxValue
 
         if result <> 0 then failwith "Website shut down." }
 
@@ -222,12 +229,9 @@ Target "RunSSR" (fun _ ->
     |> ignore
 )
 
-
 // --------------------------------------------------------------------------------------
 // Release Scripts
-
-
-Target "SetReleaseNotes" (fun _ ->
+Target.create "SetReleaseNotes" (fun _ ->
     let lines = [
             "module internal ReleaseNotes"
             ""
@@ -235,17 +239,17 @@ Target "SetReleaseNotes" (fun _ ->
             ""
             (sprintf "let IsPrerelease = %b" (release.SemVer.PreRelease <> None))
             ""
-            "let Notes = \"\"\""] @ Array.toList releaseNotes @ ["\"\"\""]
+            "let Notes = \"\"\""] @ Seq.toList releaseNotes @ ["\"\"\""]
     File.WriteAllLines("src/Client/ReleaseNotes.fs",lines)
 )
 
-Target "PrepareRelease" (fun _ ->
+Target.create "PrepareRelease" (fun _ ->
     Git.Branches.checkout "" false "master"
     Git.CommandHelper.directRunGitCommand "" "fetch origin" |> ignore
     Git.CommandHelper.directRunGitCommand "" "fetch origin --tags" |> ignore
 
-    StageAll ""
-    Git.Commit.Commit "" (sprintf "Bumping version to %O" release.NugetVersion)
+    Git.Staging.stageAll ""
+    Git.Commit.exec "" (sprintf "Bumping version to %O" release.NugetVersion)
     Git.Branches.pushBranch "" "origin" "master"
 
     let tagName = string release.NugetVersion
@@ -253,18 +257,22 @@ Target "PrepareRelease" (fun _ ->
     Git.Branches.pushTag "" "origin" tagName
 
     let result =
-        ExecProcess (fun info ->
-            info.FileName <- "docker"
-            info.Arguments <- sprintf "tag %s/%s %s/%s:%s" dockerUser dockerImageName dockerUser dockerImageName release.NugetVersion) TimeSpan.MaxValue
+        Process.execSimple (fun info ->
+            { info with
+                FileName = "docker"
+                Arguments = sprintf "tag %s/%s %s/%s:%s" dockerUser dockerImageName dockerUser dockerImageName release.NugetVersion }
+        ) TimeSpan.MaxValue
     if result <> 0 then failwith "Docker tag failed"
 )
 
-Target "BundleClient" (fun _ ->
+Target.create "BundleClient" (fun _ ->
     let result =
-        ExecProcess (fun info ->
-            info.FileName <- dotnetExePath
-            info.WorkingDirectory <- serverPath
-            info.Arguments <- "publish -c Release -o \"" + FullName deployDir + "\"") TimeSpan.MaxValue
+        Process.execSimple (fun info ->
+            { info with
+                FileName = dotnetExePath
+                WorkingDirectory = serverPath
+                Arguments = sprintf "publish -c Release -o \"%s\"" (Path.getFullName deployDir) }
+            ) TimeSpan.MaxValue
     if result <> 0 then failwith "Publish failed"
 
     let clientDir = deployDir </> "client"
@@ -273,69 +281,80 @@ Target "BundleClient" (fun _ ->
     let cssDir = clientDir </> "css"
     let imageDir = clientDir </> "Images"
 
-    !! "src/Client/public/**/*.*" |> CopyFiles publicDir
-    !! "src/Client/js/**/*.*" |> CopyFiles jsDir
-    !! "src/Client/css/**/*.*" |> CopyFiles cssDir
-    !! "src/Client/Images/**/*.*" |> CopyFiles imageDir
+    !! "src/Client/public/**/*.*" |> Shell.copyFiles publicDir
+    !! "src/Client/js/**/*.*" |> Shell.copyFiles jsDir
+    !! "src/Client/css/**/*.*" |> Shell.copyFiles cssDir
+    !! "src/Client/Images/**/*.*" |> Shell.copyFiles imageDir
 
-    "src/Client/index.html" |> CopyFile clientDir
+    "src/Client/index.html" |> Shell.copyFile clientDir
 )
 
-Target "CreateDockerImage" (fun _ ->
+Target.create "CreateDockerImage" (fun _ ->
     if String.IsNullOrEmpty dockerUser then
         failwithf "docker username not given."
     if String.IsNullOrEmpty dockerImageName then
         failwithf "docker image Name not given."
     let result =
-        ExecProcess (fun info ->
-            info.FileName <- "docker"
-            info.UseShellExecute <- false
-            info.Arguments <- sprintf "build -t %s/%s ." dockerUser dockerImageName) TimeSpan.MaxValue
+        Process.execSimple (fun info ->
+            { info with
+                FileName = "docker"
+                UseShellExecute = false
+                Arguments = sprintf "build -t %s/%s ." dockerUser dockerImageName }
+        ) TimeSpan.MaxValue
     if result <> 0 then failwith "Docker build failed"
 )
 
-Target "TestDockerImage" (fun _ ->
-    ActivateFinalTarget "KillProcess"
+Target.create "TestDockerImage" (fun _ ->
+    Target.activateFinal "KillProcess"
     let testImageName = "test"
 
     let result =
-        ExecProcess (fun info ->
-            info.FileName <- "docker"
-            info.Arguments <- sprintf "run -d -p 127.0.0.1:8086:8085 --rm --name %s -it %s/%s" testImageName dockerUser dockerImageName) TimeSpan.MaxValue
+        Process.execSimple (fun info ->
+            { info with
+                FileName = "docker"
+                Arguments = sprintf "run -d -p 127.0.0.1:8086:8085 --rm --name %s -it %s/%s" testImageName dockerUser dockerImageName }
+        ) TimeSpan.MaxValue
     if result <> 0 then failwith "Docker run failed"
 
     System.Threading.Thread.Sleep 5000 |> ignore  // give server some time to start
 
     !! clientTestExecutables
-    |> Expecto (fun p -> { p with Parallel = false } )
+    |> Expecto.run (fun p -> { p with Parallel = false } )
     |> ignore
 
     let result =
-        ExecProcess (fun info ->
-            info.FileName <- "docker"
-            info.Arguments <- sprintf "stop %s" testImageName) TimeSpan.MaxValue
+        Process.execSimple (fun info ->
+            { info with
+                FileName = "docker"
+                Arguments = sprintf "stop %s" testImageName }
+        ) TimeSpan.MaxValue
     if result <> 0 then failwith "Docker stop failed"
 )
 
-Target "Deploy" (fun _ ->
+Target.create "Deploy" (fun _ ->
     let result =
-        ExecProcess (fun info ->
-            info.FileName <- "docker"
-            info.WorkingDirectory <- deployDir
-            info.Arguments <- sprintf "login %s --username \"%s\" --password \"%s\"" dockerLoginServer dockerUser dockerPassword) TimeSpan.MaxValue
+        Process.execSimple (fun info ->
+            { info with
+                FileName = "docker"
+                WorkingDirectory = deployDir
+                Arguments = sprintf "login %s --username \"%s\" --password \"%s\"" dockerLoginServer dockerUser dockerPassword }
+        ) TimeSpan.MaxValue
     if result <> 0 then failwith "Docker login failed"
 
     let result =
-        ExecProcess (fun info ->
-            info.FileName <- "docker"
-            info.WorkingDirectory <- deployDir
-            info.Arguments <- sprintf "push %s/%s" dockerUser dockerImageName) TimeSpan.MaxValue
+        Process.execSimple (fun info ->
+            { info with
+                FileName = "docker"
+                WorkingDirectory = deployDir
+                Arguments = sprintf "push %s/%s" dockerUser dockerImageName }
+        ) TimeSpan.MaxValue
     if result <> 0 then failwith "Docker push failed"
 )
 
 // -------------------------------------------------------------------------------------
-Target "Build" DoNothing
-Target "All" DoNothing
+open Fake.Core.TargetOperators
+Target.create "Build" ignore
+Target.create "All" ignore
 
 "Clean"
   ==> "InstallDotNetCore"
@@ -363,4 +382,4 @@ Target "All" DoNothing
 "InstallClient"
   ==> "RunSSR"
 
-RunTargetOrDefault "All"
+Target.runOrDefault "All"

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -eu
 cd "$(dirname "$0")"
 
 PAKET_EXE=.paket/paket.exe
-FAKE_EXE=packages/build/FAKE/tools/FAKE.exe
+FAKE_EXE=.fake/FAKE.exe
 
 FSIARGS=""
 FSIARGS2=""
@@ -18,6 +18,8 @@ then
   FSIARGS2="-d:MONO"
 fi
 
+OS=${OS:-"unknown"}
+
 run() {
   if [ "$OS" != "Windows_NT" ]
   then
@@ -28,5 +30,6 @@ run() {
 }
 
 run $PAKET_EXE restore
-run $FAKE_EXE "$@" $FSIARGS $FSIARGS2 build.fsx
 
+dotnet tool install fake-cli --tool-path .\.fake
+run $FAKE_EXE build build.fsx

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -42,5 +42,12 @@ group UITests
 
 group Build
   source https://nuget.org/api/v2
-  framework >= net461
-  nuget FAKE
+  storage none
+  framework netstandard2.0
+
+  nuget Fake.Core.Target
+  nuget Fake.Core.ReleaseNotes
+  nuget Fake.DotNet.Cli
+  nuget Fake.DotNet.Testing.Expecto
+  nuget Fake.Tools.Git
+  nuget FSharp.Core 4.3.4 // Must be same version as FAKE -> https://github.com/fsharp/FAKE/issues/2001

--- a/paket.lock
+++ b/paket.lock
@@ -52,7 +52,7 @@ NUGET
       Fable.Core (>= 1.3.8) - restriction: >= netstandard1.6
       Fable.Import.Browser (>= 1.0) - restriction: >= netstandard1.6
       FSharp.Core (>= 4.2.3) - restriction: >= netstandard1.6
-    Fable.React (3.1.2)
+    Fable.React (3.1.3)
       Fable.Core (>= 1.3.12) - restriction: >= netstandard1.6
       Fable.Import.Browser (>= 1.1.1) - restriction: >= netstandard1.6
     FSharp.Compiler.Service (23.0.3) - restriction: >= netcoreapp2.0
@@ -65,7 +65,7 @@ NUGET
       System.Reflection.TypeExtensions (>= 4.3) - restriction: && (< net45) (>= netstandard2.0)
       System.Runtime.Loader (>= 4.0) - restriction: && (< net45) (>= netstandard2.0)
       System.Security.Cryptography.Algorithms (>= 4.3) - restriction: && (< net45) (>= netstandard2.0)
-    FSharp.Core (4.3.4) - redirects: force
+    FSharp.Core (4.5) - redirects: force
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Console (>= 4.0) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
@@ -117,285 +117,285 @@ NUGET
       System.Security.Cryptography.Cng (>= 4.3) - restriction: && (< net40) (>= netstandard1.4)
       System.Security.Cryptography.Csp (>= 4.3) - restriction: && (< net40) (>= netstandard1.4)
       System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: && (< net40) (>= netstandard1.4)
-    Microsoft.AspNetCore (2.1)
-      Microsoft.AspNetCore.Diagnostics (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.HostFiltering (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Json (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Console (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Debug (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Antiforgery (2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.DataProtection (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.ObjectPool (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication (2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.DataProtection (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.WebEncoders (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Core (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization.Policy (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authorization (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Connections.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Features (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore (2.1.1)
+      Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.HostFiltering (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Server.IISIntegration (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Server.Kestrel (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.CommandLine (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.UserSecrets (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Console (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Debug (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Antiforgery (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Authentication (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.DataProtection (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Authentication.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Authentication.Core (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Authorization (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Authorization.Policy (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Authorization (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Connections.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cors (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Cors (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Cryptography.Internal (2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.DataProtection (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Cryptography.Internal (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection.Abstractions (2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics (2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.DataProtection.Abstractions (2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Diagnostics (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HostFiltering (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.HostFiltering (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Hosting (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
       System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Abstractions (2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Features (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Html.Abstractions (2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Hosting.Abstractions (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Html.Abstractions (2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.ObjectPool (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Features (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Http (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Http.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Features (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Extensions (2.1) - restriction: || (>= net451) (>= netstandard1.3)
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Http.Extensions (2.1.1) - restriction: || (>= net451) (>= netstandard1.3)
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpOverrides (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.JsonPatch (2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Http.Features (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.HttpOverrides (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.JsonPatch (2.1.1) - restriction: >= netstandard2.0
       Microsoft.CSharp (>= 4.5) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc (2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor.Design (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Memory (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Core (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Localization (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Mvc (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Cors (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Localization (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Razor.Design (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Mvc.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Mvc.ApiExplorer (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Mvc.Core (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Authorization.Policy (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Routing (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
       Microsoft.Extensions.DependencyModel (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
       System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-      System.Threading.Tasks.Extensions (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Cors (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Cors (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization (>= 2.1) - restriction: >= netstandard2.0
+      System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Mvc.Cors (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Cors (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Mvc.DataAnnotations (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
       System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.JsonPatch (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Localization (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Localization (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Razor (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.AspNetCore.Mvc.Formatters.Json (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.JsonPatch (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Mvc.Localization (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Localization (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Localization (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Mvc.Razor (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.Razor (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.CodeAnalysis.Razor (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
       Microsoft.DiaSymReader.Native (>= 1.7) - restriction: >= net461
-      Microsoft.Extensions.Caching.Memory (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.FileProviders.Composite (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor.Language (>= 2.1) - restriction: || (>= net46) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.Razor (>= 2.1) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.RazorPages (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.TagHelpers (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Memory (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Antiforgery (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.WebEncoders (>= 2.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.FileProviders.Composite (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Razor.Language (>= 2.1.1) - restriction: || (>= net46) (>= netstandard2.0)
+      Microsoft.CodeAnalysis.Razor (>= 2.1.1) - restriction: || (>= net46) (>= netstandard2.0)
+    Microsoft.AspNetCore.Mvc.RazorPages (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Mvc.TagHelpers (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Caching.Memory (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Mvc.ViewFeatures (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Antiforgery (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Core (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json.Bson (>= 1.0.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Design (2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Language (2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Runtime (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.ObjectPool (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IISIntegration (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.HttpOverrides (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Razor (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Razor.Design (2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Razor.Language (2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Razor.Runtime (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Razor (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Routing (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.ObjectPool (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Routing.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Server.IISIntegration (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Authentication.Core (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.HttpOverrides (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
       System.IO.Pipelines (>= 4.5) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
       System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: >= netstandard2.0
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
       System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Core (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.1) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Server.Kestrel (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Server.Kestrel.Core (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.WebUtilities (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
       System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: >= netstandard2.0
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
       System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netstandard2.0
-      System.Threading.Tasks.Extensions (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Https (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.StaticFiles (2.1)
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.WebEncoders (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets (2.1)
-      Microsoft.AspNetCore.Http.Extensions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-      System.Net.WebSockets.WebSocketProtocol (>= 4.5) - restriction: >= netstandard2.0
+      System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Server.Kestrel.Https (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Connections.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.StaticFiles (2.1.1)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.WebEncoders (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.WebSockets (2.1.1)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+      System.Net.WebSockets.WebSocketProtocol (>= 4.5.1) - restriction: >= netstandard2.0
     Microsoft.AspNetCore.WebSockets.Protocol (0.1) - restriction: || (>= net451) (>= netstandard1.3)
       System.Diagnostics.Contracts (>= 4.0.1) - restriction: && (< net451) (>= netstandard1.3)
       System.Globalization (>= 4.0.11) - restriction: && (< net451) (>= netstandard1.3)
@@ -414,8 +414,8 @@ NUGET
       Microsoft.AspNetCore.Http.Extensions (>= 1.0) - restriction: || (>= net451) (>= netstandard1.3)
       Microsoft.AspNetCore.WebSockets.Protocol (>= 0.1) - restriction: || (>= net451) (>= netstandard1.3)
       Microsoft.Extensions.Options (>= 1.0) - restriction: || (>= net451) (>= netstandard1.3)
-    Microsoft.AspNetCore.WebUtilities (2.1) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.AspNetCore.WebUtilities (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Net.Http.Headers (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
     Microsoft.Azure.KeyVault.Core (2.0.4) - restriction: || (&& (>= net45) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= wp8))
     Microsoft.Azure.WebJobs (3.0.0-beta5)
@@ -435,7 +435,7 @@ NUGET
     Microsoft.Azure.WebJobs.Extensions (3.0.0-beta5)
       Microsoft.Azure.WebJobs (>= 3.0.0-beta5) - restriction: >= netstandard2.0
       ncrontab (>= 3.3) - restriction: >= netstandard2.0
-    Microsoft.CodeAnalysis.Analyzers (2.6) - restriction: >= netstandard2.0
+    Microsoft.CodeAnalysis.Analyzers (2.6.1) - restriction: >= netstandard2.0
     Microsoft.CodeAnalysis.Common (2.8.2) - restriction: >= netstandard2.0
       Microsoft.CodeAnalysis.Analyzers (>= 1.1) - restriction: >= netstandard1.3
       System.AppContext (>= 4.3) - restriction: >= netstandard1.3
@@ -478,8 +478,8 @@ NUGET
       System.Xml.XPath.XDocument (>= 4.3) - restriction: >= netstandard1.3
     Microsoft.CodeAnalysis.CSharp (2.8.2) - restriction: >= netstandard2.0
       Microsoft.CodeAnalysis.Common (2.8.2)
-    Microsoft.CodeAnalysis.Razor (2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor.Language (>= 2.1) - restriction: || (>= net46) (>= netstandard2.0)
+    Microsoft.CodeAnalysis.Razor (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Razor.Language (>= 2.1.1) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.Common (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
       Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: >= net46
@@ -497,94 +497,94 @@ NUGET
       System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
       System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (>= net45) (>= netstandard1.3)
-    Microsoft.Extensions.Caching.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Binder (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.CommandLine (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.FileExtensions (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Json (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Caching.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Caching.Memory (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Caching.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Configuration (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Configuration.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Configuration.Binder (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Configuration.CommandLine (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Configuration.EnvironmentVariables (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Configuration.FileExtensions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Physical (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Configuration.Json (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.1.1) - restriction: >= netstandard2.0
       Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.UserSecrets (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Json (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.DependencyInjection (2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (2.1) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.Configuration.UserSecrets (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Json (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.DependencyInjection (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Extensions.DependencyInjection.Abstractions (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
     Microsoft.Extensions.DependencyModel (2.1) - restriction: >= netstandard2.0
       Microsoft.DotNet.PlatformAbstractions (>= 2.1) - restriction: || (>= net451) (>= netstandard1.3)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= net451) (>= netstandard1.3)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
       System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.Extensions.FileProviders.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Composite (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Physical (2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileSystemGlobbing (2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting.Abstractions (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization.Abstractions (2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Abstractions (2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Configuration (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Console (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Debug (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.ObjectPool (2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options (2.1) - restriction: || (>= net451) (>= netstandard1.3)
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options.ConfigurationExtensions (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Primitives (2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Memory (>= 4.5) - restriction: >= netstandard2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.WebEncoders (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.FileProviders.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.FileProviders.Composite (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.FileProviders.Physical (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.FileSystemGlobbing (2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Hosting.Abstractions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Localization (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Localization.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Localization.Abstractions (2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Logging (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Logging.Abstractions (2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Logging.Configuration (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Logging.Console (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging.Configuration (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Logging.Debug (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Logging (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.ObjectPool (2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Options (2.1.1) - restriction: || (>= net451) (>= netstandard1.3)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Options.ConfigurationExtensions (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Configuration.Binder (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.Primitives (2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
+      System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
+    Microsoft.Extensions.WebEncoders (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Options (>= 2.1.1) - restriction: >= netstandard2.0
       System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Net.Http.Headers (2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.1) - restriction: >= netstandard2.0
+    Microsoft.Net.Http.Headers (2.1.1) - restriction: >= netstandard2.0
+      Microsoft.Extensions.Primitives (>= 2.1.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.NETCore.App (2.1) - restriction: >= netcoreapp2.0
+    Microsoft.NETCore.App (2.1.1) - restriction: >= netcoreapp2.0
     Microsoft.NETCore.Platforms (2.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (>= net45) (< netstandard1.3) (>= netstandard1.6)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< net46) (>= netstandard2.0)) (&& (>= net461) (>= netstandard1.6)) (>= netcoreapp2.0) (&& (< netstandard1.0) (>= netstandard1.6) (< portable-net45+win8)) (&& (< netstandard1.0) (>= netstandard1.6) (>= win8)) (&& (< netstandard1.0) (>= netstandard1.6) (< win8)) (&& (< netstandard1.3) (>= netstandard1.6) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (&& (>= netstandard1.6) (>= uap10.1)) (&& (>= netstandard1.6) (>= wp8)) (< portable-net45+win8+wp8+wpa81)
     Microsoft.NETCore.Targets (2.1) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (< portable-net45+win8+wp8+wpa81)
     Microsoft.Win32.Primitives (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net46) (< netstandard1.4) (>= netstandard1.6)) (>= netcoreapp2.0) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (< portable-net45+win8+wp8+wpa81)
@@ -927,10 +927,10 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
       System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Memory (4.5) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (< netcoreapp2.1) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81))
+    System.Memory (4.5.1) - restriction: >= netstandard2.0
+      System.Buffers (>= 4.4) - restriction: || (>= monoandroid) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (< netcoreapp2.1) (>= netstandard2.0)) (&& (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (>= net461) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
       System.Numerics.Vectors (>= 4.4) - restriction: || (&& (< net45) (< netcoreapp2.0) (< netcoreapp2.1) (>= netstandard2.0)) (>= net461)
-      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (>= monoandroid) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0)) (&& (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (>= net461) (>= netcoreapp2.0) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
     System.Net.Http (4.3.3) - restriction: || (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1019,12 +1019,12 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Net.WebSockets.WebSocketProtocol (4.5) - restriction: >= netstandard2.0
+    System.Net.WebSockets.WebSocketProtocol (4.5.1) - restriction: >= netstandard2.0
       System.Buffers (>= 4.4) - restriction: || (>= monoandroid) (>= monotouch) (&& (< netcoreapp2.0) (< netcoreapp2.1) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Memory (>= 4.5) - restriction: || (>= netcoreapp2.0) (&& (< netcoreapp2.1) (>= netstandard2.0)) (>= uap10.1)
+      System.Memory (>= 4.5.1) - restriction: || (>= monoandroid) (>= monotouch) (>= netcoreapp2.0) (&& (< netcoreapp2.1) (>= netstandard2.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
       System.Numerics.Vectors (>= 4.4) - restriction: && (< netcoreapp2.0) (< netcoreapp2.1) (>= netstandard2.0)
       System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (>= monoandroid) (>= monotouch) (>= netcoreapp2.0) (&& (< netcoreapp2.1) (>= netstandard2.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Threading.Tasks.Extensions (>= 4.5) - restriction: || (>= monoandroid) (>= monotouch) (>= netcoreapp2.0) (&& (< netcoreapp2.1) (>= netstandard2.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: || (>= netcoreapp2.0) (&& (< netcoreapp2.1) (>= netstandard2.0)) (>= uap10.1)
     System.Numerics.Vectors (4.5) - restriction: >= netstandard2.0
     System.ObjectModel (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81))
       System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
@@ -1074,7 +1074,7 @@ NUGET
     System.Runtime (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< net40) (>= net463)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (&& (>= net461) (>= netcoreapp1.1)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Runtime.CompilerServices.Unsafe (4.5) - restriction: >= netstandard2.0
+    System.Runtime.CompilerServices.Unsafe (4.5.1) - restriction: >= netstandard2.0
     System.Runtime.Extensions (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6) (< uap10.1)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (&& (< net451) (>= netstandard1.3)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
@@ -1291,8 +1291,8 @@ NUGET
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
     System.Threading.Tasks.Dataflow (4.9) - restriction: >= netstandard2.0
-    System.Threading.Tasks.Extensions (4.5) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0) (< win8) (< wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netstandard2.0)
-      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (>= net45) (&& (< netcoreapp2.1) (>= netstandard2.0)) (&& (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= wp8)
+    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0) (< win8) (< wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netstandard2.0)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (>= net45) (&& (< netcoreapp2.1) (>= netstandard2.0)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
     System.Threading.Tasks.Parallel (4.3) - redirects: force, restriction: || (&& (< net45) (>= netstandard1.6)) (>= netstandard2.0)
       System.Collections.Concurrent (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
       System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
@@ -1400,10 +1400,283 @@ NUGET
       Newtonsoft.Json (>= 10.0.2) - restriction: || (>= net45) (&& (>= netstandard1.0) (< netstandard1.3) (< win8)) (&& (< netstandard1.0) (>= win8)) (&& (>= netstandard1.3) (< win8)) (>= wp8) (>= wpa81)
 
 GROUP Build
-RESTRICTION: >= net461
+STORAGE: NONE
+RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FAKE (4.64.13)
+    Fake.Core.CommandLineParsing (5.1)
+      FParsec (>= 1.0.3)
+      FSharp.Core (>= 4.3.4)
+    Fake.Core.Context (5.1)
+      FSharp.Core (>= 4.3.4)
+    Fake.Core.Environment (5.1)
+      FSharp.Core (>= 4.3.4)
+    Fake.Core.FakeVar (5.1)
+      Fake.Core.Context (>= 5.1)
+      FSharp.Core (>= 4.3.4)
+    Fake.Core.Process (5.1)
+      Fake.Core.Environment (>= 5.1)
+      Fake.Core.FakeVar (>= 5.1)
+      Fake.Core.String (>= 5.1)
+      Fake.Core.Trace (>= 5.1)
+      Fake.IO.FileSystem (>= 5.1)
+      FSharp.Core (>= 4.3.4)
+      System.Diagnostics.Process (>= 4.3)
+    Fake.Core.ReleaseNotes (5.1)
+      Fake.Core.SemVer (>= 5.1)
+      Fake.Core.String (>= 5.1)
+      FSharp.Core (>= 4.3.4)
+    Fake.Core.SemVer (5.1)
+      FSharp.Core (>= 4.3.4)
+      System.Runtime.Numerics (>= 4.3)
+    Fake.Core.String (5.1)
+      FSharp.Core (>= 4.3.4)
+    Fake.Core.Target (5.1)
+      Fake.Core.CommandLineParsing (>= 5.1)
+      Fake.Core.Context (>= 5.1)
+      Fake.Core.Environment (>= 5.1)
+      Fake.Core.FakeVar (>= 5.1)
+      Fake.Core.Process (>= 5.1)
+      Fake.Core.String (>= 5.1)
+      Fake.Core.Trace (>= 5.1)
+      FSharp.Control.Reactive (>= 4.1)
+      FSharp.Core (>= 4.3.4)
+      System.Reactive.Compatibility (>= 4.0)
+    Fake.Core.Trace (5.1)
+      Fake.Core.Environment (>= 5.1)
+      Fake.Core.FakeVar (>= 5.1)
+      FSharp.Core (>= 4.3.4)
+    Fake.DotNet.Cli (5.1)
+      Fake.Core.Environment (>= 5.1)
+      Fake.Core.Process (>= 5.1)
+      Fake.Core.String (>= 5.1)
+      Fake.Core.Trace (>= 5.1)
+      Fake.IO.FileSystem (>= 5.1)
+      FSharp.Core (>= 4.3.4)
+      Newtonsoft.Json (>= 11.0.2)
+    Fake.DotNet.Testing.Expecto (5.1)
+      Fake.Core.Process (>= 5.1)
+      Fake.Core.String (>= 5.1)
+      Fake.Core.Trace (>= 5.1)
+      Fake.IO.FileSystem (>= 5.1)
+      Fake.Testing.Common (>= 5.1)
+      FSharp.Core (>= 4.3.4)
+    Fake.IO.FileSystem (5.1)
+      Fake.Core.String (>= 5.1)
+      FSharp.Core (>= 4.3.4)
+      System.Diagnostics.FileVersionInfo (>= 4.3)
+      System.IO.FileSystem.Watcher (>= 4.3)
+    Fake.Testing.Common (5.1)
+      Fake.Core.Trace (>= 5.1)
+      FSharp.Core (>= 4.3.4)
+    Fake.Tools.Git (5.1)
+      Fake.Core.Environment (>= 5.1)
+      Fake.Core.Process (>= 5.1)
+      Fake.Core.SemVer (>= 5.1)
+      Fake.Core.String (>= 5.1)
+      Fake.Core.Trace (>= 5.1)
+      Fake.IO.FileSystem (>= 5.1)
+      FSharp.Core (>= 4.3.4)
+    FParsec (1.0.3)
+      FSharp.Core (>= 4.2.3)
+      NETStandard.Library (>= 1.6.1)
+    FSharp.Control.Reactive (4.1)
+      FSharp.Core (>= 4.2.3)
+      System.Reactive (>= 4.0)
+    FSharp.Core (4.3.4)
+    Microsoft.NETCore.Platforms (2.1)
+    Microsoft.NETCore.Targets (2.1)
+    Microsoft.Win32.Primitives (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    Microsoft.Win32.Registry (4.5)
+      System.Buffers (>= 4.4)
+      System.Memory (>= 4.5)
+      System.Security.AccessControl (>= 4.5)
+      System.Security.Principal.Windows (>= 4.5)
+    NETStandard.Library (2.0.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+    Newtonsoft.Json (11.0.2)
+    runtime.native.System (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+    System.Buffers (4.5)
+    System.Collections (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Collections.Immutable (1.5)
+    System.Diagnostics.Debug (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Diagnostics.FileVersionInfo (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      System.Globalization (>= 4.3)
+      System.IO (>= 4.3)
+      System.IO.FileSystem (>= 4.3)
+      System.IO.FileSystem.Primitives (>= 4.3)
+      System.Reflection.Metadata (>= 1.4.1)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+    System.Diagnostics.Process (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.Win32.Primitives (>= 4.3)
+      Microsoft.Win32.Registry (>= 4.3)
+      runtime.native.System (>= 4.3)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.IO (>= 4.3)
+      System.IO.FileSystem (>= 4.3)
+      System.IO.FileSystem.Primitives (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Text.Encoding.Extensions (>= 4.3)
+      System.Threading (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+      System.Threading.Thread (>= 4.3)
+      System.Threading.ThreadPool (>= 4.3)
+    System.Globalization (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.IO (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.IO.FileSystem (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.IO (>= 4.3)
+      System.IO.FileSystem.Primitives (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.IO.FileSystem.Primitives (4.3)
+      System.Runtime (>= 4.3)
+    System.IO.FileSystem.Watcher (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.Win32.Primitives (>= 4.3)
+      runtime.native.System (>= 4.3)
+      System.Collections (>= 4.3)
+      System.IO.FileSystem (>= 4.3)
+      System.IO.FileSystem.Primitives (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Threading (>= 4.3)
+      System.Threading.Overlapped (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+      System.Threading.Thread (>= 4.3)
+    System.Memory (4.5.1)
+      System.Buffers (>= 4.4)
+      System.Numerics.Vectors (>= 4.4)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5)
+    System.Numerics.Vectors (4.5)
+    System.Reactive (4.0)
+      System.Runtime.InteropServices.WindowsRuntime (>= 4.3)
+    System.Reactive.Compatibility (4.0)
+      System.Reactive.Core (>= 4.0)
+      System.Reactive.Interfaces (>= 4.0)
+      System.Reactive.Linq (>= 4.0)
+      System.Reactive.PlatformServices (>= 4.0)
+      System.Reactive.Providers (>= 4.0)
+    System.Reactive.Core (4.0)
+      System.Reactive (>= 4.0)
+    System.Reactive.Interfaces (4.0)
+      System.Reactive (>= 4.0)
+    System.Reactive.Linq (4.0)
+      System.Reactive (>= 4.0)
+    System.Reactive.PlatformServices (4.0)
+      System.Reactive (>= 4.0)
+    System.Reactive.Providers (4.0)
+      System.Reactive (>= 4.0)
+    System.Reflection (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.IO (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.Reflection.Metadata (1.6)
+      System.Collections.Immutable (>= 1.5)
+    System.Reflection.Primitives (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Resources.ResourceManager (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Globalization (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.Runtime (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+    System.Runtime.CompilerServices.Unsafe (4.5.1)
+    System.Runtime.Extensions (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Runtime.Handles (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Runtime.InteropServices (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Reflection (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+    System.Runtime.InteropServices.WindowsRuntime (4.3)
+      System.Runtime (>= 4.3)
+    System.Runtime.Numerics (4.3)
+      System.Globalization (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+    System.Security.AccessControl (4.5)
+      System.Security.Principal.Windows (>= 4.5)
+    System.Security.Principal.Windows (4.5)
+    System.Text.Encoding (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Text.Encoding.Extensions (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+    System.Threading (4.3)
+      System.Runtime (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.Threading.Overlapped (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+    System.Threading.Tasks (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Threading.Thread (4.3)
+      System.Runtime (>= 4.3)
+    System.Threading.ThreadPool (4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
 
 GROUP ServerTests
 STORAGE: NONE
@@ -1413,11 +1686,11 @@ NUGET
       FSharp.Core (>= 4.0.0.1) - restriction: >= net45
       FSharp.Core (>= 4.3.2) - restriction: && (< net45) (>= netstandard2.0)
       System.Configuration.ConfigurationManager (>= 4.4) - restriction: && (< net45) (>= netstandard2.0)
-    Expecto (8.0)
+    Expecto (8.1.1)
       Argu (>= 5.1) - restriction: || (>= net461) (>= netstandard2.0)
       Mono.Cecil (>= 0.10) - restriction: || (>= net461) (>= netstandard2.0)
       System.Diagnostics.FileVersionInfo (>= 4.3) - restriction: && (< net461) (>= netstandard2.0)
-    FSharp.Core (4.3.4) - redirects: force
+    FSharp.Core (4.5) - redirects: force
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Console (>= 4.0) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
@@ -1443,7 +1716,7 @@ NUGET
       System.Threading.Timer (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
     Microsoft.DotNet.Watcher.Tools (2.0.2) - clitool: true
       Microsoft.NETCore.App (>= 2.0.7) - restriction: >= netcoreapp2.0
-    Microsoft.NETCore.App (2.1) - restriction: >= netcoreapp2.0
+    Microsoft.NETCore.App (2.1.1) - restriction: >= netcoreapp2.0
     Microsoft.NETCore.Platforms (2.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< net45) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net46) (>= netstandard2.0)) (&& (>= netcoreapp1.1) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (< netstandard1.3) (>= netstandard2.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard2.0) (< portable-net45+win8+wpa81))
     Microsoft.NETCore.Targets (2.1) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< net45) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net46) (>= netstandard2.0)) (&& (>= netcoreapp1.1) (>= netstandard2.0)) (&& (< netstandard1.3) (>= netstandard2.0)) (&& (>= netstandard2.0) (< portable-net45+win8+wpa81))
     Mono.Cecil (0.10) - restriction: || (>= net461) (>= netstandard2.0)
@@ -1485,7 +1758,7 @@ NUGET
     runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.2) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
     runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.2) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
     runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.2) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
-    System.Buffers (4.5) - restriction: || (&& (< net45) (>= net461) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (< netcoreapp2.1) (>= netstandard2.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.1) (>= netstandard2.0) (< win8))
+    System.Buffers (4.5) - restriction: || (&& (>= monoandroid) (>= netstandard2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net45) (>= net461) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (< netcoreapp2.1) (>= netstandard2.0)) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= netstandard2.0) (>= xamarinios)) (&& (>= netstandard2.0) (>= xamarinmac)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos))
     System.Collections (4.3) - redirects: force, restriction: || (&& (< net35) (>= net461) (>= netstandard1.6)) (&& (< net35) (>= netstandard2.0)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
@@ -1607,10 +1880,10 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
       System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Memory (4.5) - restriction: && (< net45) (< netcoreapp2.1) (>= netstandard2.0)
-      System.Buffers (>= 4.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (< netcoreapp2.1) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81))
+    System.Memory (4.5.1) - restriction: && (< net45) (< netcoreapp2.1) (>= netstandard2.0)
+      System.Buffers (>= 4.4) - restriction: || (>= monoandroid) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (< netcoreapp2.1) (>= netstandard2.0)) (&& (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (>= net461) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
       System.Numerics.Vectors (>= 4.4) - restriction: || (&& (< net45) (< netcoreapp2.0) (< netcoreapp2.1) (>= netstandard2.0)) (>= net461)
-      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (>= monoandroid) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0)) (&& (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (>= net461) (>= netcoreapp2.0) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
     System.Net.Http (4.3.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
       runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -1714,7 +1987,7 @@ NUGET
     System.Runtime (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.2) (>= netstandard2.0) (< win8)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< net46) (>= netstandard2.0)) (&& (>= netcoreapp1.1) (>= netstandard2.0)) (&& (< netstandard1.3) (>= netstandard2.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard2.0) (< portable-net45+win8+wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Runtime.CompilerServices.Unsafe (4.5) - restriction: || (&& (< net45) (>= net461) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= netstandard2.0) (>= uap10.1))
+    System.Runtime.CompilerServices.Unsafe (4.5.1) - restriction: || (&& (>= monoandroid) (>= netstandard2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net45) (>= net461) (>= netstandard2.0)) (&& (< net45) (< netcoreapp2.1) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (< netstandard1.1) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarinios)) (&& (>= netstandard2.0) (>= xamarinmac)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos))
     System.Runtime.Extensions (4.3) - redirects: force, restriction: || (&& (< net45) (>= netstandard1.6) (< netstandard2.0)) (&& (< net46) (>= netstandard2.0)) (&& (< netstandard1.3) (>= netstandard2.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
@@ -1891,10 +2164,10 @@ NUGET
       FSharp.Core (>= 4.3.4) - restriction: && (>= net461) (>= netstandard2.0)
       Selenium.WebDriver (>= 3.11) - restriction: && (>= net461) (>= netstandard2.0)
       System.Drawing.Common (>= 4.5.0-preview1-26216-02) - restriction: && (>= net461) (>= netstandard2.0)
-    Expecto (8.0)
+    Expecto (8.1.1)
       Argu (>= 5.1)
       Mono.Cecil (>= 0.10)
-    FSharp.Core (4.3.4) - redirects: force
+    FSharp.Core (4.5) - redirects: force
     Mono.Cecil (0.10)
     PhantomJS (2.1.1)
     Selenium.WebDriver (3.12.1) - restriction: && (>= net461) (>= netstandard2.0)

--- a/test/UITests/App.config
+++ b/test/UITests/App.config
@@ -8,6 +8,6 @@
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.3.0" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.5.0.0" />
   </dependentAssembly>
 </assemblyBinding></runtime></configuration>


### PR DESCRIPTION
MIgration to Fake 5 from Fake 4.
This is based on the work that @kunjee17 did in https://github.com/kunjee17/SAFE-BookStore

- Everything is moved to Fake 5 modules
- Use Fake-cli as global tool and install this as part of build. Already done for `build.cmd` as `build.sh` needs to fixed

Most if not all `Process.runSimple` calls kan be replaced with a call to `run`

//cc @kunjee17 