### PR TITLE
[WIP] Add typescript source component

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "remotedev": "0.2.7"
   },
   "devDependencies": {
+    "awesome-typescript-loader": "^5.2.0",
     "babel-core": "6.26.3",
     "babel-loader": "7.1.5",
     "babel-plugin-transform-runtime": "6.23.0",
@@ -16,6 +17,7 @@
     "concurrently": "3.6.1",
     "fable-loader": "1.1.6",
     "fable-utils": "1.0.6",
+    "typescript": "^3.0.1",
     "webpack": "4.16.5",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "3.1.5"

--- a/src/Client/App.fs
+++ b/src/Client/App.fs
@@ -13,6 +13,9 @@ open Client.Shared
 open Client.Pages
 open ServerCode.Domain
 
+// this should print 'hello world from tsx' on load
+JsInterop.importSideEffects "./test.tsx"
+
 JsInterop.importSideEffects "whatwg-fetch"
 JsInterop.importSideEffects "babel-polyfill"
 

--- a/src/Client/test.tsx
+++ b/src/Client/test.tsx
@@ -1,0 +1,1 @@
+console.log('hello world from tsx!')

--- a/src/Client/webpack.config.js
+++ b/src/Client/webpack.config.js
@@ -58,6 +58,10 @@ module.exports = {
             define: isProduction ? [] : ["DEBUG"]
           }
         }
+      },      
+      {
+          test: /\.tsx?$/,
+          loader: 'awesome-typescript-loader'
       },
       {
         test: /\.js$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,6 +295,19 @@ atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
+awesome-typescript-loader@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/awesome-typescript-loader/-/awesome-typescript-loader-5.2.0.tgz#d7bccf4823c45096ec24da4c12a1507d276ba15a"
+  dependencies:
+    chalk "^2.4.1"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.1.0"
+    lodash "^4.17.5"
+    micromatch "^3.1.9"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.3"
+    webpack-log "^1.2.0"
+
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -3905,6 +3918,13 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.3:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -3913,7 +3933,7 @@ source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -4198,6 +4218,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
+
 ua-parser-js@^0.7.18:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
@@ -4426,7 +4450,7 @@ webpack-dev-server@3.1.5:
     webpack-log "^1.1.2"
     yargs "11.0.0"
 
-webpack-log@^1.0.1, webpack-log@^1.1.2:
+webpack-log@^1.0.1, webpack-log@^1.1.2, webpack-log@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
   dependencies:


### PR DESCRIPTION
this shows the minimum configuration to add a typescript component into the webpack build pipeline

![image](https://user-images.githubusercontent.com/4236651/44550554-e6582e00-a724-11e8-80e5-e10daef7db11.png)

I'd define one react component in typescript and reuse it in F#.

What do you think? Would it make sense to integrate this into the BookStore, or should I just write a blog post? ;D

### Todo

[ ] Actually add a React component

### Issues

[ ] I can't reference one tsx from another, when I do ``import X from './test2'``, where there is a file `test2.tsx` next to it, it fails with 

```
Module not found: Error: Can't resolve './test2'
```

closes https://github.com/SAFE-Stack/SAFE-BookStore/issues/359