### PR TITLE
WIP: Update Fable 2.2 & Fable.Core v3

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -17,14 +17,35 @@
     <PaketExeImage Condition=" '$(PaketBootstrapperStyle)' == 'proj' ">native</PaketExeImage>
     <MonoPath Condition="'$(MonoPath)' == '' And Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
     <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
-    <!-- Paket command -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket')">$(PaketToolsPath)paket</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe')">$(PaketRootPath)paket.exe</PaketExePath>
 
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe')">$(PaketToolsPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketExeImage)' == 'assembly' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketExeImage)' == 'native' AND Exists('$(PaketToolsPath)paket')  ">$(PaketToolsPath)paket</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' ">paket</PaketExePath>
+    <!-- PaketBootStrapper  -->
+    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+    <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
+
+    <!-- Paket -->
+
+    <!-- windows, root => tool => proj style => bootstrapper => global -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(_PaketBootStrapperExeDir)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">paket.exe</PaketExePath>
+
+    <!-- no windows, try native paket as default,  root => tool => proj style => mono paket => bootstrpper => global -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
+
+    <!-- no windows, try mono paket -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+
+    <!-- no windows, try bootstrapper -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket.exe</PaketExePath>
+
+    <!-- no windows, try global native paket -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' ">paket</PaketExePath>
 
     <!-- Paket command -->
     <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
@@ -32,8 +53,7 @@
     <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
     <PaketCommand Condition=" '$(PaketCommand)' == '' ">"$(PaketExePath)"</PaketCommand>
 
-    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
-    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
 
@@ -42,6 +62,11 @@
     <!-- see https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1032-fsharp-in-dotnet-sdk.md -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+
+    <!-- Disable Paket restore under NCrunch build -->
+    <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
+
+    <PaketIntermediateOutputPath Condition=" '$(PaketIntermediateOutputPath)' == '' ">$(BaseIntermediateOutputPath.TrimEnd('\').TrimEnd('\/'))</PaketIntermediateOutputPath>
   </PropertyGroup>
 
   <Target Name="PaketBootstrapping" Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">
@@ -82,24 +107,28 @@
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(PaketPropsVersion)' != '5.174.2' ">
+	<!--
+		This value should match the version in the props generated by paket
+		If they differ, this means we need to do a restore in order to ensure correct dependencies
+	-->
+    <PropertyGroup Condition="'$(PaketPropsVersion)' != '5.185.3' ">
       <PaketRestoreRequired>true</PaketRestoreRequired>
     </PropertyGroup>
 
     <!-- Do a global restore if required -->
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
-    <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
-
+    <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
+    
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>
       <!-- Don't include all frameworks when msbuild explicitly asks for a single one -->
       <MyTargetFrameworks Condition="'$(TargetFrameworks)' != '' AND '$(TargetFramework)' == '' " Include="$(TargetFrameworks)"></MyTargetFrameworks>
-      <PaketResolvedFilePaths Include="@(MyTargetFrameworks -> '$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).%(Identity).paket.resolved')"></PaketResolvedFilePaths>
+      <PaketResolvedFilePaths Include="@(MyTargetFrameworks -> '$(PaketIntermediateOutputPath)\$(MSBuildProjectFile).%(Identity).paket.resolved')"></PaketResolvedFilePaths>
     </ItemGroup>
     <Message Importance="low" Text="MyTargetFrameworks=@(MyTargetFrameworks) PaketResolvedFilePaths=@(PaketResolvedFilePaths)" />
     <PropertyGroup>
-      <PaketReferencesCachedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
+      <PaketReferencesCachedFilePath>$(PaketIntermediateOutputPath)\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
       <!-- MyProject.fsproj.paket.references has the highest precedence -->
       <PaketOriginalReferencesFilePath>$(MSBuildProjectFullPath).paket.references</PaketOriginalReferencesFilePath>
       <!-- MyProject.paket.references -->
@@ -134,8 +163,8 @@
 
     <!-- Step 3 Restore project specific stuff if required -->
     <Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --output-path "$(PaketIntermediateOutputPath)" --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --output-path "$(PaketIntermediateOutputPath)" --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
 
     <!-- This shouldn't actually happen, but just to be sure. -->
     <PropertyGroup>
@@ -163,11 +192,12 @@
         <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' == '6' And %(PaketReferencesFileLinesInfo.CopyLocal) == 'false'">runtime</ExcludeAssets>
         <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' != '6' And %(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
         <Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
+        <AllowExplicitVersion>true</AllowExplicitVersion>
       </PackageReference>
     </ItemGroup>
 
     <PropertyGroup>
-      <PaketCliToolFilePath>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).paket.clitools</PaketCliToolFilePath>
+      <PaketCliToolFilePath>$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).paket.clitools</PaketCliToolFilePath>
     </PropertyGroup>
 
     <ReadLinesFromFile File="$(PaketCliToolFilePath)" >
@@ -186,12 +216,12 @@
 
     <!-- Disabled for now until we know what to do with runtime deps - https://github.com/fsprojects/Paket/issues/2964
     <PropertyGroup>
-      <RestoreConfigFile>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).NuGet.Config</RestoreConfigFile>
+      <RestoreConfigFile>$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).NuGet.Config</RestoreConfigFile>
     </PropertyGroup> -->
 
   </Target>
 
-  <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
+  <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
     <PropertyGroup>
       <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
       <DetectedMSBuildVersion>$(MSBuildVersion)</DetectedMSBuildVersion>
@@ -199,9 +229,9 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
+  <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
     <ItemGroup>
-      <_NuspecFilesNewLocation Include="$(BaseIntermediateOutputPath)$(Configuration)\*.nuspec"/>
+      <_NuspecFilesNewLocation Include="$(PaketIntermediateOutputPath)\$(Configuration)\*.nuspec"/>
       <MSBuildMajorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[0])" />
       <MSBuildMinorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[1])" />
     </ItemGroup>
@@ -209,14 +239,16 @@
     <PropertyGroup>
       <PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
       <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
+      <UseMSBuild16_0_Pack>false</UseMSBuild16_0_Pack>
+      <UseMSBuild16_0_Pack Condition=" '@(MSBuildMajorVersion)' >= '16' ">true</UseMSBuild16_0_Pack>
       <UseMSBuild15_9_Pack>false</UseMSBuild15_9_Pack>
-      <UseMSBuild15_9_Pack Condition=" '@(MSBuildMajorVersion)' > '15' OR ('@(MSBuildMajorVersion)' == '15' AND '@(MSBuildMinorVersion)' > '8') ">true</UseMSBuild15_9_Pack>
+      <UseMSBuild15_9_Pack Condition=" '@(MSBuildMajorVersion)' == '15' AND '@(MSBuildMinorVersion)' > '8' ">true</UseMSBuild15_9_Pack>
       <UseMSBuild15_8_Pack>false</UseMSBuild15_8_Pack>
-      <UseMSBuild15_8_Pack Condition=" '$(NuGetToolVersion)' != '4.0.0' AND (! $(UseMSBuild15_9_Pack)) ">true</UseMSBuild15_8_Pack>
+      <UseMSBuild15_8_Pack Condition=" '$(NuGetToolVersion)' != '4.0.0' AND (! $(UseMSBuild15_9_Pack)) AND (! $(UseMSBuild16_0_Pack)) ">true</UseMSBuild15_8_Pack>
       <UseNuGet4_Pack>false</UseNuGet4_Pack>
-      <UseNuGet4_Pack Condition=" (! $(UseMSBuild15_8_Pack)) AND (! $(UseMSBuild15_9_Pack)) ">true</UseNuGet4_Pack>
-      <AdjustedNuspecOutputPath>$(BaseIntermediateOutputPath)$(Configuration)</AdjustedNuspecOutputPath>
-      <AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(BaseIntermediateOutputPath)</AdjustedNuspecOutputPath>
+      <UseNuGet4_Pack Condition=" (! $(UseMSBuild15_8_Pack)) AND (! $(UseMSBuild15_9_Pack)) AND (! $(UseMSBuild16_0_Pack)) ">true</UseNuGet4_Pack>
+      <AdjustedNuspecOutputPath>$(PaketIntermediateOutputPath)\$(Configuration)</AdjustedNuspecOutputPath>
+      <AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(PaketIntermediateOutputPath)</AdjustedNuspecOutputPath>
     </PropertyGroup>
 
     <ItemGroup>
@@ -230,6 +262,53 @@
     </ConvertToAbsolutePath>
 
     <!-- Call Pack -->
+    <PackTask Condition="$(UseMSBuild16_0_Pack)"
+              PackItem="$(PackProjectInputFile)"
+              PackageFiles="@(_PackageFiles)"
+              PackageFilesToExclude="@(_PackageFilesToExclude)"
+              PackageVersion="$(PackageVersion)"
+              PackageId="$(PackageId)"
+              Title="$(Title)"
+              Authors="$(Authors)"
+              Description="$(Description)"
+              Copyright="$(Copyright)"
+              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+              LicenseUrl="$(PackageLicenseUrl)"
+              ProjectUrl="$(PackageProjectUrl)"
+              IconUrl="$(PackageIconUrl)"
+              ReleaseNotes="$(PackageReleaseNotes)"
+              Tags="$(PackageTags)"
+              DevelopmentDependency="$(DevelopmentDependency)"
+              BuildOutputInPackage="@(_BuildOutputInPackage)"
+              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+              SymbolPackageFormat="symbols.nupkg"
+              TargetFrameworks="@(_TargetFrameworks)"
+              AssemblyName="$(AssemblyName)"
+              PackageOutputPath="$(PackageOutputAbsolutePath)"
+              IncludeSymbols="$(IncludeSymbols)"
+              IncludeSource="$(IncludeSource)"
+              PackageTypes="$(PackageType)"
+              IsTool="$(IsTool)"
+              RepositoryUrl="$(RepositoryUrl)"
+              RepositoryType="$(RepositoryType)"
+              SourceFiles="@(_SourceFiles->Distinct())"
+              NoPackageAnalysis="$(NoPackageAnalysis)"
+              MinClientVersion="$(MinClientVersion)"
+              Serviceable="$(Serviceable)"
+              FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
+              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
+              IncludeBuildOutput="$(IncludeBuildOutput)"
+              BuildOutputFolders="$(BuildOutputTargetFolder)"
+              ContentTargetFolders="$(ContentTargetFolders)"
+              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+              NuspecFile="$(NuspecFileAbsolutePath)"
+              NuspecBasePath="$(NuspecBasePath)"
+              NuspecProperties="$(NuspecProperties)"
+              PackageLicenseFile="$(PackageLicenseFile)"
+              PackageLicenseExpression="$(PackageLicenseExpression)"
+              PackageLicenseExpressionVersion="$(PackageLicenseExpressionVersion)" />
+
     <PackTask Condition="$(UseMSBuild15_9_Pack)"
               PackItem="$(PackProjectInputFile)"
               PackageFiles="@(_PackageFiles)"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Let's say we want to call our new page *Tomato*
                     //...
                     | TomatoModel ->
                         yield div [] [ words 60 "Tomatos taste good"]
-        ```    
+        ```
 
 3. Adjust the `urlUpdate` function inside `src/Client/App.fs`:
 
@@ -116,8 +116,8 @@ Let's say we want to call our new page *Tomato*
             match page, model.PageModel with
             //...
             | Some Page.Tomato, TomatoModel -> model, Cmd.none
-            | _, HomePageModel 
-            //... 
+            | _, HomePageModel
+            //...
             | _, TomatoModel ->
                 // unknown page or page does not match model -> go to home page
                 { User = None; PageModel = HomePageModel }, Cmd.none
@@ -148,7 +148,7 @@ Add the `src/Client/pages/Tomato.fs` to your `Client.fsproj` and `Server.fsproj`
     ```xml
     <Compile Include="pages/Login.fs" />
     <Compile Include="pages/Tomato.fs" /> <!-- <- our page -->
-    <Compile Include="Shared.fs" />  
+    <Compile Include="Shared.fs" />
     ```
     - `Server.fsproj`
     ```xml
@@ -183,7 +183,7 @@ Add the `src/Client/pages/Tomato.fs` to your `Client.fsproj` and `Server.fsproj`
     module Client.Tomato
 
     open Client.Styles
-    open Fable.Helpers.React
+    open Fable.React
 
     type Model = {
         Color:string
@@ -191,13 +191,13 @@ Add the `src/Client/pages/Tomato.fs` to your `Client.fsproj` and `Server.fsproj`
 
     let init() =
         { Color = "red" }
-        
+
     let view model =
         div []
             [
                 div [] [words 60 "Tomatoes taste VERY good!"]
                 div [] [words 20 (sprintf "The color of a tomato is %s" model.Color)]
-            ]        
+            ]
     ```
 
 2. Adjust the `PageModel` discriminated union in `Shared.fs`
@@ -257,7 +257,7 @@ Add the `src/Client/pages/Tomato.fs` to your `Client.fsproj` and `Server.fsproj`
 4. Change the `Tomato.view` function (and open another namespace):
 
     ```fsharp
-    open Fable.Helpers.React.Props
+    open Fable.React.Props
     //...
     let view model dispatch =
         div []
@@ -269,7 +269,7 @@ Add the `src/Client/pages/Tomato.fs` to your `Client.fsproj` and `Server.fsproj`
                     ClassName ("btn btn-primary")
                     OnClick (fun _ -> dispatch (ChangeColor "green"))]
                     [ str "No, my tomatoes are green!" ]
-            ]    
+            ]
     ```
 
 5. Edit `Shared.view` and pass the `dispatch` function to `Tomato.view`, remapping `Tomato.Msg` onto `App.Msg`
@@ -301,7 +301,7 @@ In development mode the server is automatically restarted whenever a file in `sr
 
 ### Freya on .NET Core
 
-The SAFE stack does not force you to use Giraffe/Saturn. Check out the [freya branch](https://github.com/SAFE-Stack/SAFE-BookStore/tree/freya) for an alternative implementation of the backend. 
+The SAFE stack does not force you to use Giraffe/Saturn. Check out the [freya branch](https://github.com/SAFE-Stack/SAFE-BookStore/tree/freya) for an alternative implementation of the backend.
 
 If you are new to Freya, you can find an introduction at:
 - [Freya website](https://docs.freya.io/en/latest/tutorials/getting-started-netcore.html)

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,5 +1,6 @@
 source https://nuget.org/api/v2
 storage:none
+framework: netstandard2.0
 
 nuget FSharp.Core redirects: force
 nuget Giraffe
@@ -10,20 +11,22 @@ nuget Microsoft.AspNetCore.WebSockets
 nuget Microsoft.AspNetCore.WebSockets.Server
 nuget System.Net.NetworkInformation
 nuget jose-jwt
-nuget Thoth.Json.Net
-nuget Thoth.Json.Giraffe
+nuget Thoth.Json.Net prerelease
+nuget Thoth.Json.Giraffe prerelease
 
-nuget Fable.Core
-nuget Fable.React
-nuget Fable.Elmish
-nuget Fable.Elmish.React
-nuget Fable.Elmish.Browser
-nuget Fable.Elmish.Debugger
-nuget Fable.Elmish.HMR
-nuget Fable.PowerPack
+nuget Fable.Core prerelease
+nuget Fable.Browser.Dom prerelease
+nuget Fable.Browser.WebStorage prerelease
+nuget Fable.Fetch prerelease
+nuget Fable.Promise prerelease
+nuget Fable.React prerelease
+nuget Fable.Elmish prerelease
+nuget Fable.Elmish.React prerelease
+nuget Fable.Elmish.Debugger prerelease
+nuget Fable.Elmish.HMR prerelease
 nuget Microsoft.Azure.WebJobs
 nuget Microsoft.Azure.WebJobs.Extensions
-nuget Thoth.Json
+nuget Thoth.Json prerelease
 
 nuget Microsoft.NET.Sdk.Functions
 nuget Microsoft.AspNetCore.Mvc

--- a/paket.lock
+++ b/paket.lock
@@ -1,678 +1,615 @@
 STORAGE: NONE
+RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    Fable.Core (2.0.2)
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish (2.0.3)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.PowerPack (>= 2.0.1) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish.Browser (2.1)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Elmish (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Import.Browser (>= 1.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish.Debugger (2.0.2)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Elmish (>= 2.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish.HMR (3.0.2)
-      Fable.Core (>= 2.0.1) - restriction: >= netstandard2.0
-      Fable.Elmish (>= 2.0.3) - restriction: >= netstandard2.0
-      Fable.Elmish.Browser (>= 2.1) - restriction: >= netstandard2.0
-      Fable.Elmish.React (>= 2.1) - restriction: >= netstandard2.0
-      Fable.Import.HMR (>= 0.1) - restriction: >= netstandard2.0
-      Fable.React (>= 4.1.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish.React (2.1)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Elmish (>= 2.0) - restriction: >= netstandard2.0
-      Fable.PowerPack (>= 2.0.1) - restriction: >= netstandard2.0
-      Fable.React (>= 4.0.1) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Import.Browser (1.3) - restriction: >= netstandard2.0
-      Fable.Core (>= 1.3.17) - restriction: >= netstandard1.6
-    Fable.Import.HMR (0.1) - restriction: >= netstandard2.0
-      Fable.Core (>= 1.3.17) - restriction: >= netstandard1.6
-    Fable.PowerPack (3.0)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Import.Browser (>= 1.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-      Thoth.Json (>= 2.0) - restriction: >= netstandard2.0
-    Fable.React (4.1.3)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.Import.Browser (>= 1.3) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    FSharp.Core (4.5.3) - redirects: force
-      System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Console (>= 4.0) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Diagnostics.Tools (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Globalization (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.IO (>= 4.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Linq (>= 4.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Linq.Expressions (>= 4.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Linq.Queryable (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Net.Requests (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Reflection (>= 4.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Reflection.Extensions (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Resources.ResourceManager (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Runtime (>= 4.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Runtime.Numerics (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Text.RegularExpressions (>= 4.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Threading (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Threading.Tasks (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Threading.Tasks.Parallel (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Threading.Thread (>= 4.0) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Threading.ThreadPool (>= 4.0.10) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Threading.Timer (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
+    Fable.Browser.Blob (1.0.0-alpha-001)
+      Fable.Core (>= 2.1.0-alpha-002)
+      FSharp.Core (>= 4.5.2)
+    Fable.Browser.Dom (1.0.0-alpha-004)
+      Fable.Browser.Blob (>= 1.0.0-alpha-001)
+      Fable.Browser.Event (>= 1.0.0-alpha-001)
+      Fable.Browser.WebStorage (>= 1.0.0-alpha-001)
+      Fable.Core (>= 2.1.0-alpha-002)
+      FSharp.Core (>= 4.5.2)
+    Fable.Browser.Event (1.0.0-alpha-001)
+      Fable.Core (>= 2.1.0-alpha-002)
+      FSharp.Core (>= 4.5.2)
+    Fable.Browser.WebStorage (1.0.0-alpha-001)
+      Fable.Browser.Event (>= 1.0.0-alpha-001)
+      Fable.Core (>= 2.1.0-alpha-002)
+      FSharp.Core (>= 4.5.2)
+    Fable.Core (3.0.0-beta-005)
+      FSharp.Core (>= 4.5.2)
+    Fable.Elmish (3.0.0-beta-7)
+      Fable.Core (>= 3.0.0-beta-004)
+      FSharp.Core (>= 4.6.2)
+    Fable.Elmish.Browser (3.0.0-beta-3)
+      Fable.Browser.Dom (>= 1.0.0-alpha-004)
+      Fable.Core (>= 3.0.0-beta-005)
+      Fable.Elmish (>= 3.0.0-beta-7)
+      FSharp.Core (>= 4.6.2)
+    Fable.Elmish.Debugger (3.0.0-beta-3)
+      Fable.Core (>= 3.0.0-beta-005)
+      Fable.Elmish (>= 3.0.0-beta-7)
+      FSharp.Core (>= 4.6.2)
+      Thoth.Json (>= 3.0.0-beta-003)
+    Fable.Elmish.HMR (4.0.0-beta-5)
+      Fable.Core (>= 3.0.0-beta-005)
+      Fable.Elmish.Browser (>= 3.0.0-beta-3)
+      Fable.Elmish.React (>= 3.0.0-beta-4)
+      FSharp.Core (>= 4.6.2)
+    Fable.Elmish.React (3.0.0-beta-4)
+      Fable.Core (>= 3.0.0-beta-005)
+      Fable.Elmish (>= 3.0.0-beta-7)
+      Fable.React (>= 5.0.0-alpha-005)
+      FSharp.Core (>= 4.6.2)
+    Fable.Fetch (2.0.0-beta-001)
+      Fable.Browser.Blob (>= 1.0.0-alpha-001)
+      Fable.Core (>= 3.0.0-beta-002)
+      Fable.Promise (>= 2.0.0-beta-001)
+      FSharp.Core (>= 4.5.2)
+    Fable.Promise (2.0.0-beta-001)
+      Fable.Core (>= 3.0.0-beta-002)
+      FSharp.Core (>= 4.5.2)
+    Fable.React (5.0.0-beta-006)
+      Fable.Browser.Dom (>= 1.0.0-alpha-004)
+      FSharp.Core (>= 4.5.2)
+    FSharp.Core (4.6.2) - redirects: force
     Giraffe (3.4)
-      FSharp.Core (>= 4.5.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Authentication (>= 2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Authorization (>= 2.1.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Diagnostics (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Newtonsoft.Json (>= 11.0.2) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Text.RegularExpressions (>= 4.3) - restriction: || (>= net461) (>= netstandard2.0)
-      System.ValueTuple (>= 4.4) - restriction: >= net461
-      System.Xml.XmlSerializer (>= 4.3) - restriction: || (>= net461) (>= netstandard2.0)
-      TaskBuilder.fs (>= 2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      Utf8Json (>= 1.3.7) - restriction: || (>= net461) (>= netstandard2.0)
+      FSharp.Core (>= 4.5.2)
+      Microsoft.AspNetCore.Authentication (>= 2.1.2)
+      Microsoft.AspNetCore.Authorization (>= 2.1.2)
+      Microsoft.AspNetCore.Diagnostics (>= 2.1.1)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.1.1)
+      Microsoft.AspNetCore.ResponseCaching (>= 2.1.1)
+      Newtonsoft.Json (>= 11.0.2)
+      System.Text.RegularExpressions (>= 4.3)
+      System.Xml.XmlSerializer (>= 4.3)
+      TaskBuilder.fs (>= 2.1)
+      Utf8Json (>= 1.3.7)
     Giraffe.TokenRouter (1.0)
-      FSharp.Core (>= 4.5.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Giraffe (>= 2.0) - restriction: || (>= net461) (>= netstandard2.0)
-      System.ValueTuple (>= 4.4) - restriction: >= net461
+      FSharp.Core (>= 4.5.2)
+      Giraffe (>= 2.0)
     jose-jwt (2.4)
-      Newtonsoft.Json (>= 9.0.1) - restriction: && (< net40) (>= netstandard1.4)
-      System.IO.Compression (>= 4.3) - restriction: && (< net40) (>= netstandard1.4)
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< net40) (>= netstandard1.4)
-      System.Runtime.Serialization.Primitives (>= 4.3) - restriction: && (< net40) (>= netstandard1.4)
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: && (< net40) (>= netstandard1.4)
-      System.Security.Cryptography.Cng (>= 4.3) - restriction: && (< net40) (>= netstandard1.4)
-      System.Security.Cryptography.Csp (>= 4.3) - restriction: && (< net40) (>= netstandard1.4)
-      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: && (< net40) (>= netstandard1.4)
-    Microsoft.AspNet.WebApi.Client (5.2.7) - restriction: && (< net46) (>= netstandard2.0)
-      Newtonsoft.Json (>= 10.0.1) - restriction: && (< net45) (>= netstandard2.0)
-      Newtonsoft.Json.Bson (>= 1.0.1) - restriction: && (< net45) (>= netstandard2.0)
+      Newtonsoft.Json (>= 9.0.1)
+      System.IO.Compression (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Runtime.Serialization.Primitives (>= 4.3)
+      System.Security.Cryptography.Algorithms (>= 4.3)
+      System.Security.Cryptography.Cng (>= 4.3)
+      System.Security.Cryptography.Csp (>= 4.3)
+      System.Security.Cryptography.X509Certificates (>= 4.3)
+    Microsoft.AspNet.WebApi.Client (5.2.7)
+      Newtonsoft.Json (>= 10.0.1)
+      Newtonsoft.Json.Bson (>= 1.0.1)
     Microsoft.AspNetCore (2.2)
-      Microsoft.AspNetCore.Diagnostics (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.HostFiltering (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.IIS (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.IISIntegration (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.CommandLine (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Json (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.UserSecrets (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Console (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Debug (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.EventSource (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Antiforgery (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.DataProtection (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.ObjectPool (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication (2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Authentication.Core (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.DataProtection (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.WebEncoders (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authentication.Core (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization (2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Authorization.Policy (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authorization (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Connections.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Features (>= 2.2) - restriction: >= netstandard2.0
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cors (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Cryptography.Internal (2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Cryptography.Internal (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Win32.Registry (>= 4.5) - restriction: >= netstandard2.0
-      System.Security.Cryptography.Xml (>= 4.5) - restriction: >= netstandard2.0
-      System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.DataProtection.Abstractions (2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics (2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-      System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-      System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Diagnostics.Abstractions (2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HostFiltering (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-      System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-      System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Abstractions (2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Features (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Html.Abstractions (2.2) - restriction: >= netstandard2.0
-      System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.ObjectPool (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Features (>= 2.2) - restriction: >= netstandard2.0
-      System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Extensions (2.2) - restriction: || (>= net451) (>= netstandard1.3)
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.2) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Http.Features (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.HttpOverrides (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.JsonPatch (2.2) - restriction: >= netstandard2.0
-      Microsoft.CSharp (>= 4.5) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Localization (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Diagnostics (>= 2.2)
+      Microsoft.AspNetCore.HostFiltering (>= 2.2)
+      Microsoft.AspNetCore.Hosting (>= 2.2)
+      Microsoft.AspNetCore.Routing (>= 2.2)
+      Microsoft.AspNetCore.Server.IIS (>= 2.2)
+      Microsoft.AspNetCore.Server.IISIntegration (>= 2.2)
+      Microsoft.AspNetCore.Server.Kestrel (>= 2.2)
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.2)
+      Microsoft.Extensions.Configuration.CommandLine (>= 2.2)
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.2)
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.2)
+      Microsoft.Extensions.Configuration.Json (>= 2.2)
+      Microsoft.Extensions.Configuration.UserSecrets (>= 2.2)
+      Microsoft.Extensions.Logging (>= 2.2)
+      Microsoft.Extensions.Logging.Configuration (>= 2.2)
+      Microsoft.Extensions.Logging.Console (>= 2.2)
+      Microsoft.Extensions.Logging.Debug (>= 2.2)
+      Microsoft.Extensions.Logging.EventSource (>= 2.2)
+    Microsoft.AspNetCore.Antiforgery (2.2)
+      Microsoft.AspNetCore.DataProtection (>= 2.2)
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.AspNetCore.WebUtilities (>= 2.2)
+      Microsoft.Extensions.ObjectPool (>= 2.2)
+    Microsoft.AspNetCore.Authentication (2.2)
+      Microsoft.AspNetCore.Authentication.Core (>= 2.2)
+      Microsoft.AspNetCore.DataProtection (>= 2.2)
+      Microsoft.AspNetCore.Http (>= 2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+      Microsoft.Extensions.WebEncoders (>= 2.2)
+    Microsoft.AspNetCore.Authentication.Abstractions (2.2)
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+    Microsoft.AspNetCore.Authentication.Core (2.2)
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Http (>= 2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+    Microsoft.AspNetCore.Authorization (2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+    Microsoft.AspNetCore.Authorization.Policy (2.2)
+      Microsoft.AspNetCore.Authentication.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Authorization (>= 2.2)
+    Microsoft.AspNetCore.Connections.Abstractions (2.2)
+      Microsoft.AspNetCore.Http.Features (>= 2.2)
+      System.IO.Pipelines (>= 4.5.2)
+    Microsoft.AspNetCore.Cors (2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.2)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+    Microsoft.AspNetCore.Cryptography.Internal (2.2)
+    Microsoft.AspNetCore.DataProtection (2.2)
+      Microsoft.AspNetCore.Cryptography.Internal (>= 2.2)
+      Microsoft.AspNetCore.DataProtection.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+      Microsoft.Win32.Registry (>= 4.5)
+      System.Security.Cryptography.Xml (>= 4.5)
+      System.Security.Principal.Windows (>= 4.5)
+    Microsoft.AspNetCore.DataProtection.Abstractions (2.2)
+    Microsoft.AspNetCore.Diagnostics (2.2)
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.AspNetCore.WebUtilities (>= 2.2)
+      Microsoft.Extensions.FileProviders.Physical (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+      System.Diagnostics.DiagnosticSource (>= 4.5)
+      System.Reflection.Metadata (>= 1.6)
+    Microsoft.AspNetCore.Diagnostics.Abstractions (2.2)
+    Microsoft.AspNetCore.HostFiltering (2.2)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Http (>= 2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+    Microsoft.AspNetCore.Hosting (2.2)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Http (>= 2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.Extensions.Configuration (>= 2.2)
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.2)
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.2)
+      Microsoft.Extensions.DependencyInjection (>= 2.2)
+      Microsoft.Extensions.FileProviders.Physical (>= 2.2)
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+      System.Diagnostics.DiagnosticSource (>= 4.5)
+      System.Reflection.Metadata (>= 1.6)
+    Microsoft.AspNetCore.Hosting.Abstractions (2.2)
+      Microsoft.AspNetCore.Hosting.Server.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2)
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.2)
+    Microsoft.AspNetCore.Hosting.Server.Abstractions (2.2)
+      Microsoft.AspNetCore.Http.Features (>= 2.2)
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.2)
+    Microsoft.AspNetCore.Html.Abstractions (2.2)
+      System.Text.Encodings.Web (>= 4.5)
+    Microsoft.AspNetCore.Http (2.2.2)
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.WebUtilities (>= 2.2)
+      Microsoft.Extensions.ObjectPool (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+      Microsoft.Net.Http.Headers (>= 2.2)
+    Microsoft.AspNetCore.Http.Abstractions (2.2)
+      Microsoft.AspNetCore.Http.Features (>= 2.2)
+      System.Text.Encodings.Web (>= 4.5)
+    Microsoft.AspNetCore.Http.Extensions (2.2)
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2)
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2)
+      Microsoft.Net.Http.Headers (>= 2.2)
+      System.Buffers (>= 4.5)
+    Microsoft.AspNetCore.Http.Features (2.2)
+      Microsoft.Extensions.Primitives (>= 2.2)
+    Microsoft.AspNetCore.HttpOverrides (2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+    Microsoft.AspNetCore.JsonPatch (2.2)
+      Microsoft.CSharp (>= 4.5)
+      Newtonsoft.Json (>= 11.0.2)
+    Microsoft.AspNetCore.Localization (2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.Extensions.Localization.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
     Microsoft.AspNetCore.Mvc (2.2)
-      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Cors (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Localization (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor.Design (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Memory (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Analyzers (2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ApiExplorer (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Core (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authorization.Policy (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyModel (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      System.Diagnostics.DiagnosticSource (>= 4.5) - restriction: >= netstandard2.0
-      System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Cors (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Cors (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.DataAnnotations (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization (>= 2.2) - restriction: >= netstandard2.0
-      System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Formatters.Json (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.JsonPatch (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Localization (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Localization (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.Razor (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.Razor (>= 2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.DiaSymReader.Native (>= 1.7) - restriction: >= net461
-      Microsoft.Extensions.Caching.Memory (>= 2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.Extensions.FileProviders.Composite (>= 2.2) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor.Language (>= 2.2) - restriction: || (>= net46) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.Razor (>= 2.2) - restriction: || (>= net46) (>= netstandard2.0)
-    Microsoft.AspNetCore.Mvc.RazorPages (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.TagHelpers (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Razor (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor.Runtime (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Memory (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.ViewFeatures (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Antiforgery (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.WebEncoders (>= 2.2) - restriction: >= netstandard2.0
-      Newtonsoft.Json.Bson (>= 1.0.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Mvc.WebApiCompatShim (2.2) - restriction: && (< net46) (>= netstandard2.0)
-      Microsoft.AspNet.WebApi.Client (>= 5.2.6) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Core (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Design (2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Language (2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Razor.Runtime (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Html.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching (2.2) - restriction: || (>= net461) (>= netstandard2.0)
-      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Memory (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.ObjectPool (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Routing.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IIS (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netstandard2.0
-      System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.IISIntegration (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Authentication.Core (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.HttpOverrides (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-      System.IO.Pipelines (>= 4.5.2) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Security.Principal.Windows (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Core (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.WebUtilities (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.2) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Numerics.Vectors (>= 4.5) - restriction: >= netstandard2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netstandard2.0
-      System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Https (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Connections.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
+      Microsoft.AspNetCore.Mvc.Analyzers (>= 2.2)
+      Microsoft.AspNetCore.Mvc.ApiExplorer (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Cors (>= 2.2)
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Localization (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.2)
+      Microsoft.AspNetCore.Mvc.RazorPages (>= 2.2)
+      Microsoft.AspNetCore.Mvc.TagHelpers (>= 2.2)
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.2)
+      Microsoft.AspNetCore.Razor.Design (>= 2.2)
+      Microsoft.Extensions.Caching.Memory (>= 2.2)
+      Microsoft.Extensions.DependencyInjection (>= 2.2)
+    Microsoft.AspNetCore.Mvc.Abstractions (2.2)
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.2)
+      Microsoft.Net.Http.Headers (>= 2.2)
+    Microsoft.AspNetCore.Mvc.Analyzers (2.2)
+    Microsoft.AspNetCore.Mvc.ApiExplorer (2.2)
+      Microsoft.AspNetCore.Mvc.Core (>= 2.2)
+    Microsoft.AspNetCore.Mvc.Core (2.2.2)
+      Microsoft.AspNetCore.Authentication.Core (>= 2.2)
+      Microsoft.AspNetCore.Authorization.Policy (>= 2.2)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Http (>= 2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Routing (>= 2.2)
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.2)
+      Microsoft.Extensions.DependencyInjection (>= 2.2)
+      Microsoft.Extensions.DependencyModel (>= 2.1)
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      System.Diagnostics.DiagnosticSource (>= 4.5)
+      System.Threading.Tasks.Extensions (>= 4.5.1)
+    Microsoft.AspNetCore.Mvc.Cors (2.2)
+      Microsoft.AspNetCore.Cors (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Core (>= 2.2)
+    Microsoft.AspNetCore.Mvc.DataAnnotations (2.2)
+      Microsoft.AspNetCore.Mvc.Core (>= 2.2)
+      Microsoft.Extensions.Localization (>= 2.2)
+      System.ComponentModel.Annotations (>= 4.5)
+    Microsoft.AspNetCore.Mvc.Formatters.Json (2.2)
+      Microsoft.AspNetCore.JsonPatch (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Core (>= 2.2)
+    Microsoft.AspNetCore.Mvc.Localization (2.2)
+      Microsoft.AspNetCore.Localization (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.2)
+      Microsoft.Extensions.DependencyInjection (>= 2.2)
+      Microsoft.Extensions.Localization (>= 2.2)
+    Microsoft.AspNetCore.Mvc.Razor (2.2)
+      Microsoft.AspNetCore.Mvc.Razor.Extensions (>= 2.2)
+      Microsoft.AspNetCore.Mvc.ViewFeatures (>= 2.2)
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.2)
+      Microsoft.CodeAnalysis.CSharp (>= 2.8)
+      Microsoft.CodeAnalysis.Razor (>= 2.2)
+      Microsoft.Extensions.Caching.Memory (>= 2.2)
+      Microsoft.Extensions.FileProviders.Composite (>= 2.2)
+    Microsoft.AspNetCore.Mvc.Razor.Extensions (2.2)
+      Microsoft.AspNetCore.Razor.Language (>= 2.2)
+      Microsoft.CodeAnalysis.Razor (>= 2.2)
+    Microsoft.AspNetCore.Mvc.RazorPages (2.2)
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.2)
+    Microsoft.AspNetCore.Mvc.TagHelpers (2.2)
+      Microsoft.AspNetCore.Mvc.Razor (>= 2.2)
+      Microsoft.AspNetCore.Razor.Runtime (>= 2.2)
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.2)
+      Microsoft.Extensions.Caching.Memory (>= 2.2)
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.2)
+      Microsoft.Extensions.Primitives (>= 2.2)
+    Microsoft.AspNetCore.Mvc.ViewFeatures (2.2)
+      Microsoft.AspNetCore.Antiforgery (>= 2.2)
+      Microsoft.AspNetCore.Diagnostics.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Core (>= 2.2)
+      Microsoft.AspNetCore.Mvc.DataAnnotations (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.2)
+      Microsoft.Extensions.WebEncoders (>= 2.2)
+      Newtonsoft.Json.Bson (>= 1.0.1)
+    Microsoft.AspNetCore.Mvc.WebApiCompatShim (2.2)
+      Microsoft.AspNet.WebApi.Client (>= 5.2.6)
+      Microsoft.AspNetCore.Mvc.Core (>= 2.2)
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.2)
+      Microsoft.AspNetCore.WebUtilities (>= 2.2)
+    Microsoft.AspNetCore.Razor (2.2)
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.2)
+    Microsoft.AspNetCore.Razor.Design (2.2)
+    Microsoft.AspNetCore.Razor.Language (2.2)
+    Microsoft.AspNetCore.Razor.Runtime (2.2)
+      Microsoft.AspNetCore.Html.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Razor (>= 2.2)
+    Microsoft.AspNetCore.ResponseCaching (2.2)
+      Microsoft.AspNetCore.Http (>= 2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.AspNetCore.ResponseCaching.Abstractions (>= 2.2)
+      Microsoft.Extensions.Caching.Memory (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+    Microsoft.AspNetCore.ResponseCaching.Abstractions (2.2)
+      Microsoft.Extensions.Primitives (>= 2.2)
+    Microsoft.AspNetCore.Routing (2.2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.AspNetCore.Routing.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.ObjectPool (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+    Microsoft.AspNetCore.Routing.Abstractions (2.2)
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2)
+    Microsoft.AspNetCore.Server.IIS (2.2.2)
+      Microsoft.AspNetCore.Authentication.Core (>= 2.2)
+      Microsoft.AspNetCore.Connections.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2)
+      System.IO.Pipelines (>= 4.5.2)
+      System.Security.Principal.Windows (>= 4.5)
+    Microsoft.AspNetCore.Server.IISIntegration (2.2.1)
+      Microsoft.AspNetCore.Authentication.Core (>= 2.2)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Http (>= 2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.AspNetCore.HttpOverrides (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+      System.Buffers (>= 4.5)
+      System.IO.Pipelines (>= 4.5.2)
+      System.Memory (>= 4.5.1)
+      System.Numerics.Vectors (>= 4.5)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.1)
+      System.Security.Principal.Windows (>= 4.5)
+    Microsoft.AspNetCore.Server.Kestrel (2.2)
+      Microsoft.AspNetCore.Hosting (>= 2.2)
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.2)
+      Microsoft.AspNetCore.Server.Kestrel.Https (>= 2.2)
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (>= 2.2)
+    Microsoft.AspNetCore.Server.Kestrel.Core (2.2)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Http (>= 2.2)
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.WebUtilities (>= 2.2)
+      Microsoft.Extensions.Configuration.Binder (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+      Microsoft.Net.Http.Headers (>= 2.2)
+      System.Memory (>= 4.5.1)
+      System.Numerics.Vectors (>= 4.5)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.1)
+      System.Security.Cryptography.Cng (>= 4.5)
+      System.Threading.Tasks.Extensions (>= 4.5.1)
+    Microsoft.AspNetCore.Server.Kestrel.Https (2.2)
+      Microsoft.AspNetCore.Http.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Server.Kestrel.Core (>= 2.2)
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (2.2)
+      Microsoft.AspNetCore.Connections.Abstractions (>= 2.2)
+    Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (2.2.1)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
     Microsoft.AspNetCore.StaticFiles (2.2)
-      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.WebEncoders (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets (2.2)
-      Microsoft.AspNetCore.Http.Extensions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-      System.Net.WebSockets.WebSocketProtocol (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.AspNetCore.WebSockets.Protocol (0.1) - restriction: || (>= net451) (>= netstandard1.3)
-      System.Diagnostics.Contracts (>= 4.0.1) - restriction: && (< net451) (>= netstandard1.3)
-      System.Globalization (>= 4.0.11) - restriction: && (< net451) (>= netstandard1.3)
-      System.IO (>= 4.1) - restriction: && (< net451) (>= netstandard1.3)
-      System.Linq (>= 4.1) - restriction: && (< net451) (>= netstandard1.3)
-      System.Net.WebSockets (>= 4.0) - restriction: && (< net451) (>= netstandard1.3)
-      System.Resources.ResourceManager (>= 4.0.1) - restriction: && (< net451) (>= netstandard1.3)
-      System.Runtime.Extensions (>= 4.1) - restriction: && (< net451) (>= netstandard1.3)
-      System.Runtime.InteropServices (>= 4.1) - restriction: && (< net451) (>= netstandard1.3)
-      System.Security.Cryptography.Algorithms (>= 4.2) - restriction: && (< net451) (>= netstandard1.3)
-      System.Text.Encoding.Extensions (>= 4.0.11) - restriction: && (< net451) (>= netstandard1.3)
-      System.Threading (>= 4.0.11) - restriction: && (< net451) (>= netstandard1.3)
-      System.Threading.Tasks (>= 4.0.11) - restriction: && (< net451) (>= netstandard1.3)
-      System.Threading.Timer (>= 4.0.1) - restriction: && (< net451) (>= netstandard1.3)
+      Microsoft.AspNetCore.Hosting.Abstractions (>= 2.2)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.WebEncoders (>= 2.2)
+    Microsoft.AspNetCore.WebSockets (2.2.1)
+      Microsoft.AspNetCore.Http.Extensions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+      System.Net.WebSockets.WebSocketProtocol (>= 4.5.3)
+    Microsoft.AspNetCore.WebSockets.Protocol (0.1)
+      System.Diagnostics.Contracts (>= 4.0.1)
+      System.Globalization (>= 4.0.11)
+      System.IO (>= 4.1)
+      System.Linq (>= 4.1)
+      System.Net.WebSockets (>= 4.0)
+      System.Resources.ResourceManager (>= 4.0.1)
+      System.Runtime.Extensions (>= 4.1)
+      System.Runtime.InteropServices (>= 4.1)
+      System.Security.Cryptography.Algorithms (>= 4.2)
+      System.Text.Encoding.Extensions (>= 4.0.11)
+      System.Threading (>= 4.0.11)
+      System.Threading.Tasks (>= 4.0.11)
+      System.Threading.Timer (>= 4.0.1)
     Microsoft.AspNetCore.WebSockets.Server (0.1)
-      Microsoft.AspNetCore.Http.Extensions (>= 1.0) - restriction: || (>= net451) (>= netstandard1.3)
-      Microsoft.AspNetCore.WebSockets.Protocol (>= 0.1) - restriction: || (>= net451) (>= netstandard1.3)
-      Microsoft.Extensions.Options (>= 1.0) - restriction: || (>= net451) (>= netstandard1.3)
-    Microsoft.AspNetCore.WebUtilities (2.2) - restriction: >= netstandard2.0
-      Microsoft.Net.Http.Headers (>= 2.2) - restriction: >= netstandard2.0
-      System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Azure.KeyVault.Core (3.0.1) - restriction: || (&& (>= net45) (>= netstandard2.0)) (&& (>= netstandard2.0) (>= wp8))
-    Microsoft.Azure.WebJobs (3.0.2)
-      Microsoft.Azure.WebJobs.Core (>= 3.0.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Json (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Hosting (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.1) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-      System.Threading.Tasks.Dataflow (>= 4.8) - restriction: >= netstandard2.0
-    Microsoft.Azure.WebJobs.Core (3.0.2) - restriction: >= netstandard2.0
-      System.ComponentModel.Annotations (>= 4.4) - restriction: >= netstandard2.0
-      System.Diagnostics.TraceSource (>= 4.3) - restriction: >= netstandard2.0
-    Microsoft.Azure.WebJobs.Extensions (3.0.1)
-      Microsoft.Azure.WebJobs (>= 3.0.2) - restriction: >= netstandard2.0
-      Microsoft.Azure.WebJobs.Host.Storage (>= 3.0.2) - restriction: >= netstandard2.0
-      ncrontab.signed (>= 3.3) - restriction: >= netstandard2.0
-    Microsoft.Azure.WebJobs.Extensions.Http (3.0) - restriction: && (< net46) (>= netstandard2.0)
-      Microsoft.AspNet.WebApi.Client (>= 5.2.4) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Http (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Mvc.WebApiCompatShim (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Routing (>= 2.1) - restriction: >= netstandard2.0
-      Microsoft.Azure.WebJobs (>= 3.0) - restriction: >= netstandard2.0
-    Microsoft.Azure.WebJobs.Host.Storage (3.0.2) - restriction: >= netstandard2.0
-      Microsoft.Azure.WebJobs (>= 3.0.2) - restriction: >= netstandard2.0
-      WindowsAzure.Storage (>= 9.3.1) - restriction: >= netstandard2.0
-    Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator (1.0.1) - restriction: && (< net46) (>= netstandard2.0)
-      Microsoft.Build.Framework (>= 15.3.409) - restriction: || (>= net46) (>= netstandard2.0)
-      Microsoft.Build.Utilities.Core (>= 15.3.409) - restriction: || (>= net46) (>= netstandard2.0)
-      System.Runtime.Loader (>= 4.3) - restriction: && (< net46) (>= netstandard2.0)
-    Microsoft.Build.Framework (15.9.20) - restriction: && (< net46) (>= netstandard2.0)
-      System.Runtime.Serialization.Primitives (>= 4.1.1) - restriction: && (< net46) (>= netstandard2.0)
-      System.Threading.Thread (>= 4.0) - restriction: && (< net46) (>= netstandard2.0)
-    Microsoft.Build.Utilities.Core (15.9.20) - restriction: && (< net46) (>= netstandard2.0)
-      Microsoft.Build.Framework (>= 15.9.20) - restriction: || (>= net46) (>= netstandard2.0)
-      Microsoft.Win32.Registry (>= 4.3) - restriction: && (< net46) (>= netstandard2.0)
-      System.Collections.Immutable (>= 1.5) - restriction: || (>= net46) (>= netstandard2.0)
-      System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: || (>= net46) (>= netstandard2.0)
-      System.Text.Encoding.CodePages (>= 4.4) - restriction: && (< net46) (>= netstandard2.0)
-    Microsoft.CodeAnalysis.Analyzers (2.6.2) - restriction: >= netstandard2.0
-    Microsoft.CodeAnalysis.Common (2.10) - restriction: >= netstandard2.0
-      Microsoft.CodeAnalysis.Analyzers (>= 2.6.1) - restriction: >= netstandard1.3
-      System.AppContext (>= 4.3) - restriction: >= netstandard1.3
-      System.Collections (>= 4.3) - restriction: >= netstandard1.3
-      System.Collections.Concurrent (>= 4.3) - restriction: >= netstandard1.3
-      System.Collections.Immutable (>= 1.5) - restriction: >= netstandard1.3
-      System.Console (>= 4.3) - restriction: >= netstandard1.3
-      System.Diagnostics.Debug (>= 4.3) - restriction: >= netstandard1.3
-      System.Diagnostics.FileVersionInfo (>= 4.3) - restriction: >= netstandard1.3
-      System.Diagnostics.StackTrace (>= 4.3) - restriction: >= netstandard1.3
-      System.Diagnostics.Tools (>= 4.3) - restriction: >= netstandard1.3
-      System.Dynamic.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Globalization (>= 4.3) - restriction: >= netstandard1.3
-      System.IO.Compression (>= 4.3) - restriction: >= netstandard1.3
-      System.IO.FileSystem (>= 4.3) - restriction: >= netstandard1.3
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: >= netstandard1.3
-      System.Linq (>= 4.3) - restriction: >= netstandard1.3
-      System.Linq.Expressions (>= 4.3) - restriction: >= netstandard1.3
-      System.Reflection (>= 4.3) - restriction: >= netstandard1.3
-      System.Reflection.Metadata (>= 1.6) - restriction: >= netstandard1.3
-      System.Resources.ResourceManager (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Extensions (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.InteropServices (>= 4.3) - restriction: >= netstandard1.3
-      System.Runtime.Numerics (>= 4.3) - restriction: >= netstandard1.3
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: >= netstandard1.3
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: >= netstandard1.3
-      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding.CodePages (>= 4.3) - restriction: >= netstandard1.3
-      System.Text.Encoding.Extensions (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Tasks (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Tasks.Extensions (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Tasks.Parallel (>= 4.3) - restriction: >= netstandard1.3
-      System.Threading.Thread (>= 4.3) - restriction: >= netstandard1.3
-      System.ValueTuple (>= 4.3) - restriction: >= netstandard1.3
-      System.Xml.ReaderWriter (>= 4.3) - restriction: >= netstandard1.3
-      System.Xml.XDocument (>= 4.3) - restriction: >= netstandard1.3
-      System.Xml.XmlDocument (>= 4.3) - restriction: >= netstandard1.3
-      System.Xml.XPath.XDocument (>= 4.3) - restriction: >= netstandard1.3
-    Microsoft.CodeAnalysis.CSharp (2.10) - restriction: >= netstandard2.0
-      Microsoft.CodeAnalysis.Common (2.10)
-    Microsoft.CodeAnalysis.Razor (2.2) - restriction: >= netstandard2.0
-      Microsoft.AspNetCore.Razor.Language (>= 2.2) - restriction: || (>= net46) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.Common (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
-      Microsoft.CodeAnalysis.CSharp (>= 2.8) - restriction: || (>= net46) (>= netstandard2.0)
-      System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: >= net46
-    Microsoft.CSharp (4.5) - restriction: >= netstandard2.0
-    Microsoft.DiaSymReader.Native (1.7) - restriction: && (>= net461) (>= netstandard2.0)
-    Microsoft.DotNet.PlatformAbstractions (2.1) - restriction: >= netstandard2.0
-      System.AppContext (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.3)
-      System.IO (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.IO.FileSystem (>= 4.0.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.Reflection.TypeExtensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.Runtime.Extensions (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.Runtime.InteropServices (>= 4.1) - restriction: && (< net45) (>= netstandard1.3)
-      System.Runtime.InteropServices.RuntimeInformation (>= 4.0) - restriction: || (>= net45) (>= netstandard1.3)
-    Microsoft.Extensions.Caching.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Caching.Memory (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Caching.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Binder (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.CommandLine (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.EnvironmentVariables (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.FileExtensions (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.Json (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.FileExtensions (>= 2.2) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Configuration.UserSecrets (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Json (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.DependencyInjection (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2) - restriction: || (>= net461) (>= netstandard2.0)
-    Microsoft.Extensions.DependencyInjection.Abstractions (2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.DependencyModel (2.1) - restriction: >= netstandard2.0
-      Microsoft.DotNet.PlatformAbstractions (>= 2.1) - restriction: || (>= net451) (>= netstandard1.3)
-      Newtonsoft.Json (>= 9.0.1) - restriction: || (>= net451) (>= netstandard1.3)
-      System.Diagnostics.Debug (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-      System.Dynamic.Runtime (>= 4.0.11) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-      System.Linq (>= 4.1) - restriction: || (&& (< net451) (>= netstandard1.3) (< netstandard1.6)) (&& (< net451) (>= netstandard1.6))
-    Microsoft.Extensions.FileProviders.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Composite (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileProviders.Physical (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileSystemGlobbing (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.FileSystemGlobbing (2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Physical (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Hosting.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Hosting.Abstractions (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Localization.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Localization.Abstractions (2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Abstractions (2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Configuration (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Console (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging.Configuration (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.Debug (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Logging.EventSource (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Logging (>= 2.2) - restriction: >= netstandard2.0
-      Newtonsoft.Json (>= 11.0.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.ObjectPool (2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options (2.2) - restriction: || (>= net451) (>= netstandard1.3)
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
-      System.ComponentModel.Annotations (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Options.ConfigurationExtensions (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Configuration.Binder (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-    Microsoft.Extensions.Primitives (2.2) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5.1) - restriction: >= netstandard2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.1) - restriction: >= netstandard2.0
-    Microsoft.Extensions.WebEncoders (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Options (>= 2.2) - restriction: >= netstandard2.0
-      System.Text.Encodings.Web (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.Net.Http.Headers (2.2) - restriction: >= netstandard2.0
-      Microsoft.Extensions.Primitives (>= 2.2) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.5) - restriction: >= netstandard2.0
-    Microsoft.NET.Sdk.Functions (1.0.24)
-      Microsoft.Azure.WebJobs (>= 2.2 < 2.4) - restriction: >= net46
-      Microsoft.Azure.WebJobs (>= 3.0 < 3.1) - restriction: && (< net46) (>= netstandard2.0)
-      Microsoft.Azure.WebJobs.Extensions (>= 2.2 < 2.4) - restriction: >= net46
-      Microsoft.Azure.WebJobs.Extensions (>= 3.0 < 3.1) - restriction: && (< net46) (>= netstandard2.0)
-      Microsoft.Azure.WebJobs.Extensions.Http (>= 1.1 < 1.3) - restriction: >= net46
-      Microsoft.Azure.WebJobs.Extensions.Http (>= 3.0 < 3.1) - restriction: && (< net46) (>= netstandard2.0)
-      Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator (>= 1.0.1) - restriction: && (< net46) (>= netstandard2.0)
-      Newtonsoft.Json (9.0.1) - restriction: >= net46
-      Newtonsoft.Json (11.0.2) - restriction: && (< net46) (>= netstandard2.0)
-      System.ValueTuple (>= 4.3) - restriction: >= net46
-    Microsoft.NETCore.Platforms (2.2) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard1.0) (>= netstandard1.6)) (&& (>= net461) (< netstandard1.3) (>= netstandard1.6) (>= wpa81)) (&& (>= net461) (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= net461) (>= netstandard1.6) (>= uap10.1)) (&& (>= net461) (>= netstandard1.6) (>= wp8)) (>= netcoreapp2.0) (&& (< netstandard1.0) (>= netstandard2.0) (< portable-net45+win8)) (&& (< netstandard1.0) (>= netstandard2.0) (>= win8)) (&& (< netstandard1.0) (>= netstandard2.0) (< win8)) (&& (< netstandard1.3) (>= netstandard2.0) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard2.0) (>= uap10.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (&& (>= netstandard2.0) (< portable-net45+win8+wpa81)) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= wp8)) (< portable-net45+win8+wp8+wpa81)
-    Microsoft.NETCore.Targets (2.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (< portable-net45+win8+wp8+wpa81)
-    Microsoft.Win32.Primitives (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    Microsoft.Win32.Registry (4.5) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.4) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Memory (>= 4.5) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1)
-      System.Security.AccessControl (>= 4.5) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-    ncrontab.signed (3.3) - restriction: >= netstandard2.0
-      System.Collections (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-      System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-      System.Globalization (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-      System.IO (>= 4.1) - restriction: && (< net35) (>= netstandard1.0)
-      System.Net.Primitives (>= 4.0.11) - restriction: && (< net35) (>= netstandard1.0)
-      System.Resources.ResourceManager (>= 4.0.1) - restriction: && (< net35) (>= netstandard1.0)
-    NETStandard.Library (2.0.3) - restriction: || (&& (< net45) (>= net461) (>= netstandard1.6)) (&& (< net45) (>= netstandard2.0))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
-    Newtonsoft.Json (11.0.2) - restriction: || (&& (< net40) (>= netstandard1.4)) (>= net46) (>= netstandard2.0)
-    Newtonsoft.Json.Bson (1.0.1) - restriction: >= netstandard2.0
-      NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.3)
-      Newtonsoft.Json (>= 10.0.1) - restriction: || (>= net45) (>= netstandard1.3)
-    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.native.System (4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
+      Microsoft.AspNetCore.Http.Extensions (>= 1.0)
+      Microsoft.AspNetCore.WebSockets.Protocol (>= 0.1)
+      Microsoft.Extensions.Options (>= 1.0)
+    Microsoft.AspNetCore.WebUtilities (2.2)
+      Microsoft.Net.Http.Headers (>= 2.2)
+      System.Text.Encodings.Web (>= 4.5)
+    Microsoft.Azure.WebJobs (3.0.6)
+      Microsoft.Azure.WebJobs.Core (>= 3.0.6)
+      Microsoft.Extensions.Configuration (>= 2.1)
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.1)
+      Microsoft.Extensions.Configuration.EnvironmentVariables (>= 2.1)
+      Microsoft.Extensions.Configuration.Json (>= 2.1)
+      Microsoft.Extensions.Hosting (>= 2.1)
+      Microsoft.Extensions.Logging (>= 2.1)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.1)
+      Microsoft.Extensions.Logging.Configuration (>= 2.1)
+      Newtonsoft.Json (>= 11.0.2)
+      System.Threading.Tasks.Dataflow (>= 4.8)
+    Microsoft.Azure.WebJobs.Core (3.0.6)
+      System.ComponentModel.Annotations (>= 4.4)
+      System.Diagnostics.TraceSource (>= 4.3)
+    Microsoft.Azure.WebJobs.Extensions (3.0.2)
+      Microsoft.Azure.WebJobs (>= 3.0.4)
+      Microsoft.Azure.WebJobs.Host.Storage (>= 3.0.2)
+      NCrontab.Signed (>= 3.3)
+    Microsoft.Azure.WebJobs.Extensions.Http (3.0.2)
+      Microsoft.AspNet.WebApi.Client (>= 5.2.4)
+      Microsoft.AspNetCore.Http (>= 2.1)
+      Microsoft.AspNetCore.Mvc.Formatters.Json (>= 2.1)
+      Microsoft.AspNetCore.Mvc.WebApiCompatShim (>= 2.1)
+      Microsoft.AspNetCore.Routing (>= 2.1)
+      Microsoft.Azure.WebJobs (>= 3.0.2)
+    Microsoft.Azure.WebJobs.Host.Storage (3.0.6)
+      Microsoft.Azure.WebJobs (>= 3.0.6)
+      WindowsAzure.Storage (>= 9.3.1)
+    Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator (1.0.2)
+      Microsoft.Build.Framework (>= 15.3.409)
+      Microsoft.Build.Utilities.Core (>= 15.3.409)
+      System.Runtime.Loader (>= 4.3)
+    Microsoft.Build.Framework (16.0.461)
+      System.Runtime.Serialization.Primitives (>= 4.1.1)
+      System.Threading.Thread (>= 4.0)
+    Microsoft.Build.Utilities.Core (16.0.461)
+      Microsoft.Build.Framework (>= 16.0.461)
+      Microsoft.Win32.Registry (>= 4.3)
+      System.Collections.Immutable (>= 1.5)
+      System.Text.Encoding.CodePages (>= 4.0.1)
+    Microsoft.CodeAnalysis.Analyzers (2.9.1)
+    Microsoft.CodeAnalysis.Common (3.0)
+      Microsoft.CodeAnalysis.Analyzers (>= 2.6.2-beta2)
+      System.Collections.Immutable (>= 1.5)
+      System.Memory (>= 4.5.1)
+      System.Reflection.Metadata (>= 1.6)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5)
+      System.Text.Encoding.CodePages (>= 4.5)
+      System.Threading.Tasks.Extensions (>= 4.5)
+    Microsoft.CodeAnalysis.CSharp (3.0)
+      Microsoft.CodeAnalysis.Common (3.0)
+    Microsoft.CodeAnalysis.Razor (2.2)
+      Microsoft.AspNetCore.Razor.Language (>= 2.2)
+      Microsoft.CodeAnalysis.Common (>= 2.8)
+      Microsoft.CodeAnalysis.CSharp (>= 2.8)
+    Microsoft.CSharp (4.5)
+    Microsoft.DotNet.PlatformAbstractions (2.1)
+      System.AppContext (>= 4.1)
+      System.Collections (>= 4.0.11)
+      System.IO (>= 4.1)
+      System.IO.FileSystem (>= 4.0.1)
+      System.Reflection.TypeExtensions (>= 4.1)
+      System.Runtime.Extensions (>= 4.1)
+      System.Runtime.InteropServices (>= 4.1)
+      System.Runtime.InteropServices.RuntimeInformation (>= 4.0)
+    Microsoft.Extensions.Caching.Abstractions (2.2)
+      Microsoft.Extensions.Primitives (>= 2.2)
+    Microsoft.Extensions.Caching.Memory (2.2)
+      Microsoft.Extensions.Caching.Abstractions (>= 2.2)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+    Microsoft.Extensions.Configuration (2.2)
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.2)
+    Microsoft.Extensions.Configuration.Abstractions (2.2)
+      Microsoft.Extensions.Primitives (>= 2.2)
+    Microsoft.Extensions.Configuration.Binder (2.2.4)
+      Microsoft.Extensions.Configuration (>= 2.2)
+    Microsoft.Extensions.Configuration.CommandLine (2.2)
+      Microsoft.Extensions.Configuration (>= 2.2)
+    Microsoft.Extensions.Configuration.EnvironmentVariables (2.2.4)
+      Microsoft.Extensions.Configuration (>= 2.2)
+    Microsoft.Extensions.Configuration.FileExtensions (2.2)
+      Microsoft.Extensions.Configuration (>= 2.2)
+      Microsoft.Extensions.FileProviders.Physical (>= 2.2)
+    Microsoft.Extensions.Configuration.Json (2.2)
+      Microsoft.Extensions.Configuration (>= 2.2)
+      Microsoft.Extensions.Configuration.FileExtensions (>= 2.2)
+      Newtonsoft.Json (>= 11.0.2)
+    Microsoft.Extensions.Configuration.UserSecrets (2.2)
+      Microsoft.Extensions.Configuration.Json (>= 2.2)
+    Microsoft.Extensions.DependencyInjection (2.2)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2)
+    Microsoft.Extensions.DependencyInjection.Abstractions (2.2)
+    Microsoft.Extensions.DependencyModel (2.1)
+      Microsoft.DotNet.PlatformAbstractions (>= 2.1)
+      Newtonsoft.Json (>= 9.0.1)
+      System.Diagnostics.Debug (>= 4.0.11)
+      System.Dynamic.Runtime (>= 4.0.11)
+      System.Linq (>= 4.1)
+    Microsoft.Extensions.FileProviders.Abstractions (2.2)
+      Microsoft.Extensions.Primitives (>= 2.2)
+    Microsoft.Extensions.FileProviders.Composite (2.2)
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2)
+    Microsoft.Extensions.FileProviders.Physical (2.2)
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2)
+      Microsoft.Extensions.FileSystemGlobbing (>= 2.2)
+    Microsoft.Extensions.FileSystemGlobbing (2.2)
+    Microsoft.Extensions.Hosting (2.2)
+      Microsoft.Extensions.Configuration (>= 2.2)
+      Microsoft.Extensions.DependencyInjection (>= 2.2)
+      Microsoft.Extensions.FileProviders.Physical (>= 2.2)
+      Microsoft.Extensions.Hosting.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging (>= 2.2)
+    Microsoft.Extensions.Hosting.Abstractions (2.2)
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.2)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2)
+      Microsoft.Extensions.FileProviders.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+    Microsoft.Extensions.Localization (2.2)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2)
+      Microsoft.Extensions.Localization.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+    Microsoft.Extensions.Localization.Abstractions (2.2)
+    Microsoft.Extensions.Logging (2.2)
+      Microsoft.Extensions.Configuration.Binder (>= 2.2)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+    Microsoft.Extensions.Logging.Abstractions (2.2)
+    Microsoft.Extensions.Logging.Configuration (2.2)
+      Microsoft.Extensions.Logging (>= 2.2)
+      Microsoft.Extensions.Options.ConfigurationExtensions (>= 2.2)
+    Microsoft.Extensions.Logging.Console (2.2)
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.2)
+      Microsoft.Extensions.Logging (>= 2.2)
+      Microsoft.Extensions.Logging.Configuration (>= 2.2)
+    Microsoft.Extensions.Logging.Debug (2.2)
+      Microsoft.Extensions.Logging (>= 2.2)
+    Microsoft.Extensions.Logging.EventSource (2.2)
+      Microsoft.Extensions.Logging (>= 2.2)
+      Newtonsoft.Json (>= 11.0.2)
+    Microsoft.Extensions.ObjectPool (2.2)
+    Microsoft.Extensions.Options (2.2)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2)
+      Microsoft.Extensions.Primitives (>= 2.2)
+      System.ComponentModel.Annotations (>= 4.5)
+    Microsoft.Extensions.Options.ConfigurationExtensions (2.2)
+      Microsoft.Extensions.Configuration.Abstractions (>= 2.2)
+      Microsoft.Extensions.Configuration.Binder (>= 2.2)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+    Microsoft.Extensions.Primitives (2.2)
+      System.Memory (>= 4.5.1)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.1)
+    Microsoft.Extensions.WebEncoders (2.2)
+      Microsoft.Extensions.DependencyInjection.Abstractions (>= 2.2)
+      Microsoft.Extensions.Options (>= 2.2)
+      System.Text.Encodings.Web (>= 4.5)
+    Microsoft.Net.Http.Headers (2.2)
+      Microsoft.Extensions.Primitives (>= 2.2)
+      System.Buffers (>= 4.5)
+    Microsoft.NET.Sdk.Functions (1.0.26)
+      Microsoft.Azure.WebJobs (>= 3.0 < 3.1)
+      Microsoft.Azure.WebJobs.Extensions (>= 3.0 < 3.1)
+      Microsoft.Azure.WebJobs.Extensions.Http (>= 3.0 < 3.1)
+      Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator (>= 1.0.2)
+      Newtonsoft.Json (11.0.2)
+    Microsoft.NETCore.Platforms (2.2)
+    Microsoft.NETCore.Targets (2.1)
+    Microsoft.Win32.Primitives (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    Microsoft.Win32.Registry (4.5)
+      System.Buffers (>= 4.4)
+      System.Memory (>= 4.5)
+      System.Security.AccessControl (>= 4.5)
+      System.Security.Principal.Windows (>= 4.5)
+    NCrontab.Signed (3.3.2)
+    NETStandard.Library (2.0.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+    Newtonsoft.Json (11.0.2)
+    Newtonsoft.Json.Bson (1.0.1)
+      NETStandard.Library (>= 1.6.1)
+      Newtonsoft.Json (>= 10.0.1)
+    runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.native.System (4.3.1)
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.IO.Compression (4.3.2) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81))
+    runtime.native.System.IO.Compression (4.3.2)
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Net.Http (4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
+    runtime.native.System.Net.Http (4.3.1)
       Microsoft.NETCore.Platforms (>= 1.1.1)
       Microsoft.NETCore.Targets (>= 1.1.3)
-    runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+    runtime.native.System.Security.Cryptography.Apple (4.3.1)
       runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (>= 4.3.1)
-    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
+    runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
       runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
@@ -688,666 +625,479 @@ NUGET
       runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
       runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.3)
-    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3) - restriction: && (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.AppContext (4.3) - restriction: >= netstandard2.0
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.6)) (&& (< monoandroid) (< netstandard1.3))
-    System.Buffers (4.5) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (>= netstandard2.0)
-    System.Collections (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Collections.Concurrent (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net40) (>= net463)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netstandard2.0)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-    System.Collections.Immutable (1.5) - restriction: >= netstandard2.0
-    System.ComponentModel.Annotations (4.5) - restriction: >= netstandard2.0
-    System.Console (4.3.1) - redirects: force, restriction: || (&& (< net45) (>= netstandard1.6)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Contracts (4.3) - restriction: && (< net451) (>= netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Diagnostics.Debug (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6)) (&& (< net40) (>= net461) (< netstandard1.6)) (&& (< net40) (>= net463)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.3) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Diagnostics.DiagnosticSource (4.5.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netstandard2.0)
-    System.Diagnostics.FileVersionInfo (4.3) - restriction: >= netstandard2.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.IO.FileSystem (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Reflection.Metadata (>= 1.4.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.StackTrace (4.3) - restriction: >= netstandard2.0
-      System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Metadata (>= 1.4.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tools (4.3) - redirects: force, restriction: || (&& (< net45) (>= netstandard1.6)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Diagnostics.TraceSource (4.3) - restriction: >= netstandard2.0
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Diagnostics.Tracing (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-    System.Dynamic.Runtime (4.3) - restriction: >= netstandard2.0
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Linq (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Linq.Expressions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.ObjectModel (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Emit (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.TypeExtensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Globalization (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6)) (&& (< net40) (>= net461) (< netstandard1.6)) (&& (< net40) (>= net463)) (&& (< net45) (>= net46)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (&& (< net451) (>= netstandard1.3)) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Globalization.Calendars (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Globalization.Extensions (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IO (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< monoandroid) (< net46) (>= netstandard2.0) (< xamarinios)) (&& (< net35) (>= netstandard2.0)) (&& (< net40) (>= net463)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net46) (< netstandard2.0)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0)) (&& (< net451) (>= netstandard1.3)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.IO.Compression (4.3) - restriction: || (&& (< net40) (>= netstandard1.4)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.IO.Compression (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Buffers (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-    System.IO.FileSystem (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< net45) (>= net461)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IO.FileSystem.Primitives (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net461)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.IO.Pipelines (4.5.2) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.4) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)) (>= monotouch) (>= net46) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Memory (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (>= netstandard1.3) (< netstandard2.0)) (>= monotouch) (>= net46) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios)) (>= uap10.1)
-    System.Linq (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< net40) (>= net463)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (&& (< net451) (>= netstandard1.3)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.6) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Linq.Expressions (4.3) - redirects: force, restriction: || (&& (< net45) (>= netstandard1.6)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Linq (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.ObjectModel (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Emit (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Emit.Lightweight (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.TypeExtensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Linq.Queryable (4.3) - redirects: force, restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Linq (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Linq.Expressions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Memory (4.5.1) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= netstandard2.0)
-      System.Buffers (>= 4.4) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Numerics.Vectors (>= 4.4) - restriction: || (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios)) (>= net461)
-      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-    System.Net.Http (4.3.4) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
-      Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Diagnostics.DiagnosticSource (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Globalization.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Net.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81))
-      System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (>= net46) (< portable-net45+win8+wpa81)
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
+    runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple (4.3.1)
+    runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl (4.3.3)
+    System.AppContext (4.3)
+      System.Runtime (>= 4.3)
+    System.Buffers (4.5)
+    System.Collections (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Collections.Concurrent (4.3)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Diagnostics.Tracing (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Threading (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.Collections.Immutable (1.5)
+    System.ComponentModel.Annotations (4.5)
+    System.Diagnostics.Contracts (4.3)
+      System.Runtime (>= 4.3)
+    System.Diagnostics.Debug (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Diagnostics.DiagnosticSource (4.5.1)
+    System.Diagnostics.TraceSource (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      runtime.native.System (>= 4.3)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Threading (>= 4.3)
+    System.Diagnostics.Tracing (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Dynamic.Runtime (4.3)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Linq (>= 4.3)
+      System.Linq.Expressions (>= 4.3)
+      System.ObjectModel (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Reflection.Emit (>= 4.3)
+      System.Reflection.Emit.ILGeneration (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Reflection.TypeExtensions (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Threading (>= 4.3)
+    System.Globalization (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Globalization.Calendars (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Globalization (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.IO (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.IO.Compression (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      runtime.native.System (>= 4.3)
+      runtime.native.System.IO.Compression (>= 4.3)
+      System.Buffers (>= 4.3)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.IO (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Threading (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.IO.FileSystem (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.IO (>= 4.3)
+      System.IO.FileSystem.Primitives (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.IO.FileSystem.Primitives (4.3)
+      System.Runtime (>= 4.3)
+    System.IO.Pipelines (4.5.3)
+      System.Buffers (>= 4.4)
+      System.Memory (>= 4.5.1)
+      System.Threading.Tasks.Extensions (>= 4.5.1)
+    System.Linq (4.3)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+    System.Linq.Expressions (4.3)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.IO (>= 4.3)
+      System.Linq (>= 4.3)
+      System.ObjectModel (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Reflection.Emit (>= 4.3)
+      System.Reflection.Emit.ILGeneration (>= 4.3)
+      System.Reflection.Emit.Lightweight (>= 4.3)
+      System.Reflection.Extensions (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Reflection.TypeExtensions (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Threading (>= 4.3)
+    System.Memory (4.5.2)
+      System.Buffers (>= 4.4)
+      System.Numerics.Vectors (>= 4.4)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.2)
     System.Net.NetworkInformation (4.3)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.Win32.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO.FileSystem (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Net.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Net.Sockets (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.InteropServices.WindowsRuntime (>= 4.3) - restriction: < portable-net45+win8+wp8+wpa81
-      System.Security.Principal.Windows (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading.Overlapped (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading.Thread (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading.ThreadPool (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Net.Primitives (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.6) (< win8)) (&& (< net35) (>= netstandard2.0)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Net.Requests (4.3) - redirects: force, restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8)) (< portable-net45+win8+wp8+wpa81)
-      System.Net.Http (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Net.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8)) (< portable-net45+win8+wp8+wpa81)
-      System.Net.WebHeaderCollection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Net.Sockets (4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Net.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Net.WebHeaderCollection (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Net.WebSockets (4.3) - restriction: && (< net451) (>= netstandard1.3)
-      Microsoft.Win32.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Net.WebSockets.WebSocketProtocol (4.5.2) - restriction: >= netstandard2.0
-      System.Buffers (>= 4.4) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Memory (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Numerics.Vectors (>= 4.4) - restriction: && (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios)
-      System.Runtime.CompilerServices.Unsafe (>= 4.5.2) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Threading.Tasks.Extensions (>= 4.5.1) - restriction: || (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios)) (>= uap10.1)
-    System.Numerics.Vectors (4.5) - restriction: >= netstandard2.0
-    System.ObjectModel (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81))
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Reflection (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (>= netcoreapp1.1) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Reflection.Emit (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (>= net47) (&& (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81))
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Reflection.Emit.ILGeneration (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81))
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Reflection.Emit.Lightweight (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< netstandard2.0)) (>= net47) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< wp8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Reflection.Extensions (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Reflection.Metadata (1.6) - restriction: >= netstandard2.0
-      System.Collections.Immutable (>= 1.5) - restriction: || (>= net45) (&& (< netcoreapp2.1) (>= netstandard2.0)) (&& (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81))
-    System.Reflection.Primitives (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.2) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (>= netcoreapp1.1) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Reflection.TypeExtensions (4.5.1) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard2.0)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81))
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.5) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.5) (< uap10.1)) (&& (< monoandroid) (< netstandard1.3))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.5) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.5) (< uap10.1)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.5) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.5) (< uap10.1)) (&& (< monoandroid) (< netstandard1.3))
-    System.Resources.ResourceManager (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6) (< uap10.1)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (&& (< net451) (>= netstandard1.3)) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Runtime (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< net40) (>= net463)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (&& (>= net461) (>= netcoreapp1.1)) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Runtime.CompilerServices.Unsafe (4.5.2) - restriction: || (&& (>= net45) (>= netcoreapp2.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (>= netcoreapp2.0) (< netstandard1.0)) (&& (>= netcoreapp2.0) (>= wp8)) (>= netstandard2.0)
-    System.Runtime.Extensions (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6) (< uap10.1)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (&& (< net451) (>= netstandard1.3)) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Runtime.Handles (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6) (< uap10.1)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.InteropServices (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net40) (>= netstandard1.4)) (&& (< net45) (>= net461)) (&& (< net451) (>= netstandard1.3)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1) (< portable-net45+win8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1) (< portable-net45+win8+wpa81)
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1) (< portable-net45+win8+wpa81)
-      System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1) (< portable-net45+win8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= net462) (>= netcoreapp1.1) (< portable-net45+win8+wpa81)
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (>= netcoreapp1.1) (< portable-net45+win8+wpa81)
-    System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: >= netstandard2.0
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (< win8))
-      System.Reflection.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (< win8))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (< win8))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (< win8))
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.1) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.1) (< win8))
-    System.Runtime.InteropServices.WindowsRuntime (4.3) - restriction: < portable-net45+win8+wp8+wpa81
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Runtime.Loader (4.3) - restriction: && (< net46) (>= netstandard2.0)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Runtime.Numerics (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= netstandard1.6)) (>= netstandard2.0)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-    System.Runtime.Serialization.Primitives (4.3) - restriction: || (&& (< net40) (>= netstandard1.4)) (&& (< net46) (>= netstandard2.0))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Security.AccessControl (4.5) - restriction: || (&& (>= monotouch) (>= netstandard2.0)) (&& (< net46) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (>= netcoreapp2.0) (&& (>= netstandard2.0) (>= xamarinmac)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios)
-      Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
-      System.Security.Principal.Windows (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.0)
-    System.Security.Claims (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net46) (< netstandard2.0))
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Principal (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Algorithms (4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net40) (>= netstandard1.4)) (&& (< net451) (>= netstandard1.3)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      runtime.native.System.Security.Cryptography.Apple (>= 4.3.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< netstandard1.3)) (>= net463)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< netstandard1.3)) (>= net463)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime.Numerics (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3)) (>= net463)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< netstandard1.3)) (&& (>= net46) (< netstandard1.4)) (&& (>= net461) (< netstandard1.6)) (>= net463)
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-    System.Security.Cryptography.Cng (4.5) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net40) (>= netstandard1.4)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 2.0) - restriction: && (>= netcoreapp2.0) (< netcoreapp2.1)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1))
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1))
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1))
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1))
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1)) (&& (>= net46) (< netstandard1.4))
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1))
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1)) (&& (>= net46) (< netstandard1.4))
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6) (< uap10.1))
-    System.Security.Cryptography.Csp (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net40) (>= netstandard1.4))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Reflection (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-      System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.Encoding (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6) (< uap10.1)) (&& (< net40) (>= net463)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections.Concurrent (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.OpenSsl (4.5) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
-      Microsoft.NETCore.Platforms (>= 2.0) - restriction: && (>= netcoreapp2.0) (< netcoreapp2.1)
-      System.Collections (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.IO (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.Runtime (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.Runtime.Handles (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.Runtime.Numerics (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-      System.Text.Encoding (>= 4.3) - restriction: && (>= netstandard1.6) (< netstandard2.0)
-    System.Security.Cryptography.Pkcs (4.5.1) - restriction: && (< net461) (>= netstandard2.0)
-      System.Buffers (>= 4.4) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Memory (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard2.0)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
-      System.Security.Cryptography.Cng (>= 4.4) - restriction: || (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios)) (&& (>= netcoreapp2.0) (< netcoreapp2.1))
-      System.Security.Cryptography.Cng (>= 4.5) - restriction: >= netcoreapp2.1
-    System.Security.Cryptography.Primitives (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< netstandard2.0) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6)) (&& (< net40) (>= net461) (< netstandard1.6)) (&& (< net40) (>= net463)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81))
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net40) (>= netstandard1.4)) (&& (< net45) (>= net46) (>= netstandard1.6)) (&& (>= netstandard1.6) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      runtime.native.System (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Globalization.Calendars (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.IO.FileSystem (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Runtime.Numerics (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Security.Cryptography.Algorithms (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< netstandard1.3)) (&& (>= net46) (< netstandard1.4)) (>= net461)
-      System.Security.Cryptography.Cng (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Security.Cryptography.Csp (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard1.4)) (&& (< monoandroid) (< net46) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< netstandard1.3)) (&& (>= net46) (< netstandard1.4)) (>= net461)
-      System.Security.Cryptography.OpenSsl (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Security.Cryptography.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.3))
-    System.Security.Cryptography.Xml (4.5) - restriction: >= netstandard2.0
-      System.Security.Cryptography.Pkcs (>= 4.5) - restriction: && (< net461) (>= netstandard2.0)
-      System.Security.Permissions (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Permissions (4.5) - restriction: >= netstandard2.0
-      System.Security.AccessControl (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Security.Principal (4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Security.Principal.Windows (4.5.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
-      Microsoft.Win32.Primitives (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Collections (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Reflection (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Runtime (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Runtime.Handles (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Runtime.InteropServices (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Security.Claims (>= 4.3) - restriction: || (&& (>= net46) (< net461) (< netstandard2.0)) (&& (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1))
-      System.Security.Principal (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Text.Encoding (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-      System.Threading (>= 4.3) - restriction: && (< net46) (>= netstandard1.3) (< netstandard2.0) (< uap10.1)
-    System.Text.Encoding (4.3) - redirects: force, restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6) (< uap10.1)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (&& (>= netstandard1.3) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Text.Encoding.CodePages (4.5) - restriction: >= netstandard2.0
-      Microsoft.NETCore.Platforms (>= 2.0) - restriction: >= netcoreapp2.0
-      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< net46) (>= netstandard2.0) (< xamarinios)) (>= net461) (>= netcoreapp2.0)
-    System.Text.Encoding.Extensions (4.3) - restriction: || (&& (< net45) (>= net461)) (&& (< net451) (>= netstandard1.3)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Text.Encodings.Web (4.5) - restriction: >= netstandard2.0
-    System.Text.RegularExpressions (4.3) - restriction: || (&& (< net45) (>= netstandard1.6)) (>= net461) (>= netstandard2.0)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (>= netcoreapp1.1) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Threading (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (&& (< net451) (>= netstandard1.3)) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Threading.Overlapped (4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< net46) (>= netstandard1.3)) (< netstandard1.3)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3)) (< netstandard1.3)
-      System.Runtime (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3)) (< netstandard1.3)
-      System.Runtime.Handles (>= 4.3) - restriction: || (&& (< net46) (>= netstandard1.3)) (< netstandard1.3)
-    System.Threading.Tasks (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.4) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net40) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net40) (< netstandard1.3) (>= netstandard1.4)) (&& (< monoandroid) (< net40) (>= netstandard1.4) (< netstandard1.6)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net40) (>= net461) (< netstandard1.6)) (&& (< net40) (>= net463)) (&& (< net40) (>= netstandard1.4) (< portable-net45+win8+wpa81)) (&& (< net45) (>= net461)) (&& (< net45) (>= netstandard1.6)) (&& (< net451) (>= netstandard1.3)) (>= netstandard2.0) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Threading.Tasks.Dataflow (4.9) - restriction: >= netstandard2.0
-    System.Threading.Tasks.Extensions (4.5.1) - restriction: || (>= net461) (&& (>= netcoreapp2.0) (< netcoreapp2.1)) (>= netstandard2.0)
-      System.Runtime.CompilerServices.Unsafe (>= 4.5) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.0) (< netstandard2.0) (< win8) (< wpa81) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< win8)) (>= net45) (&& (< netcoreapp2.1) (>= netstandard2.0) (< xamarinios)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard2.0) (>= wpa81)) (>= wp8)
-    System.Threading.Tasks.Parallel (4.3) - redirects: force, restriction: || (&& (< net45) (>= netstandard1.6)) (>= netstandard2.0)
-      System.Collections.Concurrent (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Diagnostics.Tracing (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wpa81)
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (< portable-net45+win8+wpa81)
-    System.Threading.Thread (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= netstandard1.6)) (>= netstandard2.0)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Threading.ThreadPool (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0))
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Threading.Timer (4.3) - redirects: force, restriction: || (&& (< net45) (>= netstandard1.6) (< netstandard2.0)) (&& (< net451) (>= netstandard1.3))
-      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.2) (< win81) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net451+win81+wpa81)
-      Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.2) (< win81) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net451+win81+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net451) (>= netstandard1.2) (< win81) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net451+win81+wpa81)
-    System.ValueTuple (4.5) - restriction: || (&& (< net45) (>= net461) (>= netstandard1.6)) (>= net46) (&& (>= net461) (< netstandard1.6)) (>= netstandard2.0)
-    System.Xml.ReaderWriter (4.3.1) - restriction: || (&& (< net45) (>= net461)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.IO.FileSystem (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.IO.FileSystem.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.InteropServices (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Text.Encoding.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading.Tasks (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading.Tasks.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Xml.XDocument (4.3) - restriction: >= netstandard2.0
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Debug (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Diagnostics.Tools (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Text.Encoding (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-    System.Xml.XmlDocument (4.3) - restriction: || (&& (< net45) (>= net461)) (&& (>= net461) (< portable-net45+win8+wp8+wpa81)) (>= netstandard2.0)
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XmlSerializer (4.3) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Collections (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Globalization (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.IO (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Linq (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Emit (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Emit.ILGeneration (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Reflection.TypeExtensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Resources.ResourceManager (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Runtime.Extensions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Text.RegularExpressions (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Threading (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-      System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (< portable-net45+win8+wp8+wpa81)
-      System.Xml.XmlDocument (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (< portable-net45+win8+wp8+wpa81)
-    System.Xml.XPath (4.3) - restriction: || (&& (< monoandroid) (>= netstandard2.0) (< xamarinios)) (&& (>= net46) (>= netstandard2.0))
-      System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Globalization (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.IO (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Xml.XPath.XDocument (4.3) - restriction: >= netstandard2.0
-      System.Diagnostics.Debug (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Linq (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.ReaderWriter (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.XDocument (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-      System.Xml.XPath (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
-    TaskBuilder.fs (2.1) - restriction: || (>= net461) (>= netstandard2.0)
-      FSharp.Core (>= 4.1.17) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6)) (&& (< net45) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.6)) (>= net47)
-      NETStandard.Library (>= 1.6.1) - restriction: && (< net45) (>= netstandard1.6)
-      System.ValueTuple (>= 4.4) - restriction: || (&& (>= net45) (< net46) (< netstandard1.6)) (&& (< net45) (>= netstandard1.6)) (&& (>= net46) (< netstandard1.6)) (>= net47)
-    Thoth.Json (2.5)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.Win32.Primitives (>= 4.3)
+      runtime.native.System (>= 4.3)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Tracing (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.IO (>= 4.3)
+      System.IO.FileSystem (>= 4.3)
+      System.IO.FileSystem.Primitives (>= 4.3)
+      System.Linq (>= 4.3)
+      System.Net.Primitives (>= 4.3)
+      System.Net.Sockets (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Security.Principal.Windows (>= 4.3)
+      System.Threading (>= 4.3)
+      System.Threading.Overlapped (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+      System.Threading.Thread (>= 4.3)
+      System.Threading.ThreadPool (>= 4.3)
+    System.Net.Primitives (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+    System.Net.Sockets (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.IO (>= 4.3)
+      System.Net.Primitives (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.Net.WebSockets (4.3)
+      Microsoft.Win32.Primitives (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.Net.WebSockets.WebSocketProtocol (4.5.3)
+      System.Buffers (>= 4.4)
+      System.Memory (>= 4.5.1)
+      System.Numerics.Vectors (>= 4.4)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.2)
+      System.Threading.Tasks.Extensions (>= 4.5.1)
+    System.Numerics.Vectors (4.5)
+    System.ObjectModel (4.3)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Threading (>= 4.3)
+    System.Reflection (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.IO (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.Reflection.Emit (4.3)
+      System.IO (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Reflection.Emit.ILGeneration (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.Reflection.Emit.ILGeneration (4.3)
+      System.Reflection (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.Reflection.Emit.Lightweight (4.3)
+      System.Reflection (>= 4.3)
+      System.Reflection.Emit.ILGeneration (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.Reflection.Extensions (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Reflection (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.Reflection.Metadata (1.6)
+      System.Collections.Immutable (>= 1.5)
+    System.Reflection.Primitives (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Reflection.TypeExtensions (4.5.1)
+    System.Resources.ResourceManager (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Globalization (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.Runtime (4.3.1)
+      Microsoft.NETCore.Platforms (>= 1.1.1)
+      Microsoft.NETCore.Targets (>= 1.1.3)
+    System.Runtime.CompilerServices.Unsafe (4.5.2)
+    System.Runtime.Extensions (4.3.1)
+      Microsoft.NETCore.Platforms (>= 1.1.1)
+      Microsoft.NETCore.Targets (>= 1.1.3)
+      System.Runtime (>= 4.3.1)
+    System.Runtime.Handles (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Runtime.InteropServices (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Reflection (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+    System.Runtime.InteropServices.RuntimeInformation (4.3)
+      runtime.native.System (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Reflection.Extensions (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Threading (>= 4.3)
+    System.Runtime.Loader (4.3)
+      System.IO (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.Runtime.Numerics (4.3)
+      System.Globalization (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+    System.Runtime.Serialization.Primitives (4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+    System.Security.AccessControl (4.5)
+      System.Security.Principal.Windows (>= 4.5)
+    System.Security.Cryptography.Algorithms (4.3.1)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      runtime.native.System.Security.Cryptography.Apple (>= 4.3.1)
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2)
+      System.Collections (>= 4.3)
+      System.IO (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Runtime.Numerics (>= 4.3)
+      System.Security.Cryptography.Encoding (>= 4.3)
+      System.Security.Cryptography.Primitives (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+    System.Security.Cryptography.Cng (4.5)
+    System.Security.Cryptography.Csp (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      System.IO (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Security.Cryptography.Algorithms (>= 4.3)
+      System.Security.Cryptography.Encoding (>= 4.3)
+      System.Security.Cryptography.Primitives (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Threading (>= 4.3)
+    System.Security.Cryptography.Encoding (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3)
+      System.Collections (>= 4.3)
+      System.Collections.Concurrent (>= 4.3)
+      System.Linq (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Security.Cryptography.Primitives (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+    System.Security.Cryptography.OpenSsl (4.5.1)
+    System.Security.Cryptography.Pkcs (4.5.2)
+      System.Buffers (>= 4.4)
+      System.Memory (>= 4.5.1)
+      System.Security.Cryptography.Cng (>= 4.4)
+    System.Security.Cryptography.Primitives (4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.IO (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Threading (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.Security.Cryptography.X509Certificates (4.3.2)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      runtime.native.System (>= 4.3)
+      runtime.native.System.Net.Http (>= 4.3)
+      runtime.native.System.Security.Cryptography.OpenSsl (>= 4.3.2)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.Globalization.Calendars (>= 4.3)
+      System.IO (>= 4.3)
+      System.IO.FileSystem (>= 4.3)
+      System.IO.FileSystem.Primitives (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Runtime.Numerics (>= 4.3)
+      System.Security.Cryptography.Algorithms (>= 4.3)
+      System.Security.Cryptography.Cng (>= 4.3)
+      System.Security.Cryptography.Csp (>= 4.3)
+      System.Security.Cryptography.Encoding (>= 4.3)
+      System.Security.Cryptography.OpenSsl (>= 4.3)
+      System.Security.Cryptography.Primitives (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Threading (>= 4.3)
+    System.Security.Cryptography.Xml (4.5)
+      System.Security.Cryptography.Pkcs (>= 4.5)
+      System.Security.Permissions (>= 4.5)
+    System.Security.Permissions (4.5)
+      System.Security.AccessControl (>= 4.5)
+    System.Security.Principal.Windows (4.5.1)
+    System.Text.Encoding (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Text.Encoding.CodePages (4.5.1)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.2)
+    System.Text.Encoding.Extensions (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+    System.Text.Encodings.Web (4.5)
+    System.Text.RegularExpressions (4.3)
+      System.Collections (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Threading (>= 4.3)
+    System.Threading (4.3)
+      System.Runtime (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+    System.Threading.Overlapped (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+    System.Threading.Tasks (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.Threading.Tasks.Dataflow (4.9)
+    System.Threading.Tasks.Extensions (4.5.2)
+      System.Runtime.CompilerServices.Unsafe (>= 4.5.2)
+    System.Threading.Thread (4.3)
+      System.Runtime (>= 4.3)
+    System.Threading.ThreadPool (4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Handles (>= 4.3)
+    System.Threading.Timer (4.3)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      Microsoft.NETCore.Targets (>= 1.1)
+      System.Runtime (>= 4.3)
+    System.ValueTuple (4.5)
+    System.Xml.ReaderWriter (4.3.1)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.IO (>= 4.3)
+      System.IO.FileSystem (>= 4.3)
+      System.IO.FileSystem.Primitives (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Runtime.InteropServices (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Text.Encoding.Extensions (>= 4.3)
+      System.Text.RegularExpressions (>= 4.3)
+      System.Threading.Tasks (>= 4.3)
+      System.Threading.Tasks.Extensions (>= 4.3)
+    System.Xml.XmlDocument (4.3)
+      System.Collections (>= 4.3)
+      System.Diagnostics.Debug (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.IO (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Text.Encoding (>= 4.3)
+      System.Threading (>= 4.3)
+      System.Xml.ReaderWriter (>= 4.3)
+    System.Xml.XmlSerializer (4.3)
+      System.Collections (>= 4.3)
+      System.Globalization (>= 4.3)
+      System.IO (>= 4.3)
+      System.Linq (>= 4.3)
+      System.Reflection (>= 4.3)
+      System.Reflection.Emit (>= 4.3)
+      System.Reflection.Emit.ILGeneration (>= 4.3)
+      System.Reflection.Extensions (>= 4.3)
+      System.Reflection.Primitives (>= 4.3)
+      System.Reflection.TypeExtensions (>= 4.3)
+      System.Resources.ResourceManager (>= 4.3)
+      System.Runtime (>= 4.3)
+      System.Runtime.Extensions (>= 4.3)
+      System.Text.RegularExpressions (>= 4.3)
+      System.Threading (>= 4.3)
+      System.Xml.ReaderWriter (>= 4.3)
+      System.Xml.XmlDocument (>= 4.3)
+    TaskBuilder.fs (2.1)
+      FSharp.Core (>= 4.1.17)
+      NETStandard.Library (>= 1.6.1)
+      System.ValueTuple (>= 4.4)
+    Thoth.Json (3.0.0-beta-005)
+      Fable.Core (>= 3.0.0-beta-004)
+      FSharp.Core (>= 4.6.2)
     Thoth.Json.Giraffe (1.1)
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-      Giraffe (>= 3.1) - restriction: >= netstandard2.0
-      Thoth.Json.Net (>= 2.0) - restriction: >= netstandard2.0
-    Thoth.Json.Net (2.5)
-      FSharp.Core (>= 4.5.2) - restriction: || (>= net46) (>= netstandard2.0)
-      Newtonsoft.Json (>= 11.0.2) - restriction: || (>= net46) (>= netstandard2.0)
-    Utf8Json (1.3.7) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Reflection.Emit (>= 4.3) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
-      System.Reflection.Emit.Lightweight (>= 4.3) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
-      System.Threading.Tasks.Extensions (>= 4.4) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
-      System.ValueTuple (>= 4.4) - restriction: || (&& (>= net45) (< netstandard2.0)) (&& (< net45) (>= netstandard2.0)) (>= net47)
-    WindowsAzure.Storage (9.3.3) - restriction: >= netstandard2.0
-      Microsoft.Azure.KeyVault.Core (>= 1.0) - restriction: || (>= net45) (>= wp8)
-      NETStandard.Library (>= 1.6.1) - restriction: || (&& (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< win8) (< wpa81))
-      Newtonsoft.Json (>= 10.0.2) - restriction: || (>= net45) (&& (>= netstandard1.0) (< netstandard1.3) (< win8)) (&& (< netstandard1.0) (>= win8)) (&& (>= netstandard1.3) (< win8)) (>= wp8) (>= wpa81)
+      FSharp.Core (>= 4.5.2)
+      Giraffe (>= 3.1)
+      Thoth.Json.Net (>= 2.0)
+    Thoth.Json.Net (3.0.0-beta-005)
+      FSharp.Core
+      Newtonsoft.Json (>= 11.0.2)
+    Utf8Json (1.3.7)
+      System.Reflection.Emit (>= 4.3)
+      System.Reflection.Emit.Lightweight (>= 4.3)
+      System.Threading.Tasks.Extensions (>= 4.4)
+      System.ValueTuple (>= 4.4)
+    WindowsAzure.Storage (9.3.3)
+      NETStandard.Library (>= 1.6.1)
+      Newtonsoft.Json (>= 10.0.2)
 
 GROUP Build
 RESTRICTION: >= net461

--- a/src/Client/Client.fsproj
+++ b/src/Client/Client.fsproj
@@ -6,6 +6,7 @@
     <Compile Include="ReleaseNotes.fs" />
     <Compile Include="../Server/Shared/Domain.fs" />
     <Compile Include="../Server/Shared/ServerUrls.fs" />
+    <Compile Include="LocalStorage.fs" />
     <Compile Include="Pages.fs" />
     <Compile Include="Styles.fs" />
     <Compile Include="views/Menu.fs" />
@@ -13,7 +14,7 @@
     <Compile Include="pages/NewBook.fs" />
     <Compile Include="pages/WishList.fs" />
     <Compile Include="pages/Login.fs" />
-    <Compile Include="Shared.fs" />  
+    <Compile Include="Shared.fs" />
     <Compile Include="App.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/src/Client/LocalStorage.fs
+++ b/src/Client/LocalStorage.fs
@@ -1,0 +1,15 @@
+module LocalStorage
+
+open Thoth.Json
+
+let load (decoder: Decoder<'T>) key: Result<'T,string> =
+    let o = Browser.WebStorage.localStorage.getItem(key) :?> string
+    if isNull o
+    then "No item found in local storage with key " + key |> Error
+    else Decode.fromString decoder o
+
+let delete key =
+    Browser.WebStorage.localStorage.removeItem(key)
+
+let save key (data: 'T) =
+    Browser.WebStorage.localStorage.setItem(key, Encode.Auto.toString(0, data))

--- a/src/Client/Shared.fs
+++ b/src/Client/Shared.fs
@@ -8,9 +8,9 @@ type PageModel =
     | WishListModel of WishList.Model
 
 // DEMO03 - The complete app state
-type Model = { 
+type Model = {
     User : UserData option
-    PageModel : PageModel 
+    PageModel : PageModel
 }
 
 /// The composed set of messages that update the state of the application
@@ -25,8 +25,8 @@ type Msg =
 
 // VIEW
 
-open Fable.Helpers.React
-open Fable.Helpers.React.Props
+open Fable.React
+open Fable.React.Props
 open Client.Styles
 
 // DEMO05 - the whole world put into a single view
@@ -42,6 +42,6 @@ let view model dispatch =
             | LoginModel m ->
                 yield Login.view m (LoginMsg >> dispatch)
             | WishListModel m ->
-                yield WishList.view m (WishListMsg >> dispatch) 
+                yield WishList.view m (WishListMsg >> dispatch)
         ]
     ]

--- a/src/Client/Styles.fs
+++ b/src/Client/Styles.fs
@@ -1,53 +1,48 @@
 module Client.Styles
 
-open Fable.Helpers.React.Props
+open Fable.React.Props
 open System
 open Fable.Core.JsInterop
 open Fable.Import
-open Fable.PowerPack
 open Elmish.Browser.Navigation
+open Fable.React
 
-module R = Fable.Helpers.React
 
-
-let goToUrl (e: React.MouseEvent) =
+let goToUrl (e: Browser.Types.MouseEvent) =
     e.preventDefault()
     let href = !!e.target?href
     Navigation.newUrl href |> List.map (fun f -> f ignore) |> ignore
 
 let viewLink page description =
-    R.a [ Style [ Padding "0 20px" ]
-          Href (Pages.toPath page)
-          OnClick goToUrl]
-        [ R.str description]
+    a [ Style [ Padding "0 20px" ]
+        Href (Pages.toPath page)
+        OnClick goToUrl ]
+        [ str description ]
 
 let centerStyle direction =
-    Style [ Display "flex"
+    Style [ Display Display.Flex
             FlexDirection direction
-            AlignItems "center"
+            AlignItems AlignItems.Center
             JustifyContent "center"
             Padding "20px 0"
     ]
 
 let words size message =
-    R.span [ Style [ FontSize (size |> sprintf "%dpx") ] ] [ R.str message ]
+    span [ Style [ FontSize (size |> sprintf "%dpx") ] ] [ str message ]
 
 let buttonLink cssClass onClick elements =
-    R.a [ ClassName cssClass
-          OnClick (fun _ -> onClick())
-          OnTouchStart (fun _ -> onClick())
-          Style [ Cursor "pointer" ] ] elements
+    a [ ClassName cssClass
+        OnClick (fun _ -> onClick())
+        OnTouchStart (fun _ -> onClick())
+        Style [ Cursor "pointer" ] ] elements
 
 let onEnter msg dispatch =
     function
-    | (ev:React.KeyboardEvent) when ev.keyCode = Keyboard.Codes.enter ->
+    | (ev:Browser.Types.KeyboardEvent) when ev.keyCode = 13. ->
         ev.preventDefault()
         dispatch msg
     | _ -> ()
     |> OnKeyDown
-
-
-open Fable.Helpers.React
 
 let errorBox msg =
     div [] [
@@ -58,10 +53,10 @@ let errorBox msg =
 
 let validatedTextBox (onChange: string -> unit) key placeholder errorText text =
     let status = if String.IsNullOrEmpty text then "" else "has-success"
-    R.div [ClassName ("form-group has-feedback " + status)] [
-         yield R.div [ClassName "input-group"] [
-             yield R.span [ClassName "input-group-addon"] [R.span [ClassName "glyphicon glyphicon glyphicon-pencil"] [] ]
-             yield R.input [
+    div [ClassName ("form-group has-feedback " + status)] [
+         yield div [ClassName "input-group"] [
+             yield span [ClassName "input-group-addon"] [span [ClassName "glyphicon glyphicon glyphicon-pencil"] [] ]
+             yield input [
                     Key key
                     Name key
                     HTMLAttr.Type "text"
@@ -70,11 +65,10 @@ let validatedTextBox (onChange: string -> unit) key placeholder errorText text =
                     Placeholder placeholder
                     OnChange (fun ev -> onChange ev.Value)]
              match errorText with
-             | Some _e -> yield R.span [ClassName "glyphicon glyphicon-remove form-control-feedback"] []
+             | Some _e -> yield span [ClassName "glyphicon glyphicon-remove form-control-feedback"] []
              | _ -> ()
          ]
          match errorText with
-         | Some e -> yield R.p [ClassName "text-danger"][str e]
+         | Some e -> yield p [ClassName "text-danger"][str e]
          | _ -> ()
     ]
-

--- a/src/Client/pages/Home.fs
+++ b/src/Client/pages/Home.fs
@@ -1,12 +1,12 @@
 module Client.Home
 
-open Fable.Helpers.React
-open Fable.Helpers.React.Props
+open Fable.React
+open Fable.React.Props
 open Client.Styles
 open Client.Pages
 
 let view () =
-    div [Key "Menu"; centerStyle "column"] [ 
+    div [Key "Menu"; centerStyle "column"] [
         viewLink Page.Login "Please login into the SAFE-Stack sample app"
         br []
         br []
@@ -20,5 +20,5 @@ let view () =
         words 15 "An end-to-end, functional-first stack for cloud-ready web development that emphasises type-safe programming."
         br []
         br []
-        words 20 ("version " + ReleaseNotes.Version) 
+        words 20 ("version " + ReleaseNotes.Version)
     ]

--- a/src/Client/pages/Login.fs
+++ b/src/Client/pages/Login.fs
@@ -1,13 +1,12 @@
 module Client.Login
 
 open Elmish
-open Fable.Helpers.React
-open Fable.Helpers.React.Props
+open Fable.React
+open Fable.React.Props
 open ServerCode.Domain
 open System
 open Fable.Core.JsInterop
-open Fable.PowerPack
-open Fable.PowerPack.Fetch.Fetch_types
+open Fetch.Types
 open ServerCode
 open Client.Styles
 #if FABLE_COMPILER
@@ -35,7 +34,7 @@ let authUser (login:Login) = promise {
 
     let body = Encode.Auto.toString(0, login)
 
-    let props = [ 
+    let props = [
         RequestProperties.Method HttpMethod.POST
         Fetch.requestHeaders [ HttpRequestHeaders.ContentType "application/json" ]
         RequestProperties.Body !^body
@@ -53,16 +52,16 @@ let authUser (login:Login) = promise {
 
 let init (user:UserData option) =
     let userName = user |> Option.map (fun u -> u.UserName) |> Option.defaultValue ""
-            
+
     { Login = { UserName = userName; Password = ""; PasswordId = Guid.NewGuid() }
       Running = false
       ErrorMsg = None }, Cmd.none
-    
+
 let update (msg:Msg) model : Model*Cmd<Msg> =
     match msg with
     | LoginSuccess _ ->
         // DEMO07 - some messages are handled one level above
-        model, Cmd.none 
+        model, Cmd.none
 
     | SetUserName name ->
         { model with Login = { model.Login with UserName = name; Password = ""; PasswordId = Guid.NewGuid() } }, Cmd.none
@@ -72,22 +71,22 @@ let update (msg:Msg) model : Model*Cmd<Msg> =
 
     | LogInClicked ->
         // DEMO08 - javascript promises
-        { model with Running = true }, 
-            Cmd.ofPromise authUser model.Login LoginSuccess AuthError
+        { model with Running = true },
+            Cmd.OfPromise.either authUser model.Login LoginSuccess AuthError
 
     | AuthError exn ->
         { model with Running = false; ErrorMsg = Some exn.Message }, Cmd.none
 
 let view model (dispatch: Msg -> unit) =
-    let buttonActive = 
-        if String.IsNullOrEmpty model.Login.UserName || 
+    let buttonActive =
+        if String.IsNullOrEmpty model.Login.UserName ||
            String.IsNullOrEmpty model.Login.Password ||
            model.Running
-        then 
+        then
             "btn-disabled"
         else
             "btn-primary"
-    
+
     div [ Key "SignIn"; ClassName "signInBox" ] [
         h3 [ ClassName "text-center" ] [ str "Log in with 'test' / 'test'."]
 
@@ -125,10 +124,10 @@ let view model (dispatch: Msg -> unit) =
         ]
 
         div [ ClassName "text-center" ] [
-            button [ 
+            button [
                 ClassName ("btn " + buttonActive)
-                OnClick (fun _ -> dispatch LogInClicked) ] [ 
-                    str "Log In" 
+                OnClick (fun _ -> dispatch LogInClicked) ] [
+                    str "Log In"
             ]
         ]
     ]

--- a/src/Client/pages/NewBook.fs
+++ b/src/Client/pages/NewBook.fs
@@ -1,7 +1,7 @@
 module Client.NewBook
 
-open Fable.Helpers.React
-open Fable.Helpers.React.Props
+open Fable.React
+open Fable.React.Props
 open Elmish
 open ServerCode.Domain
 open System
@@ -10,7 +10,7 @@ open Client.Styles
 
 type Model =
   { NewBook : Book
-    NewBookId : Guid // unique key to reset the vdom-elements, see https://github.com/SAFE-Stack/SAFE-BookStore/issues/107#issuecomment-301312224    
+    NewBookId : Guid // unique key to reset the vdom-elements, see https://github.com/SAFE-Stack/SAFE-BookStore/issues/107#issuecomment-301312224
     TitleErrorText : string option
     AuthorsErrorText : string option
     LinkErrorText : string option }
@@ -58,9 +58,9 @@ let update (msg:Msg) model : Model*Cmd<Msg> =
                 TitleErrorText = model.NewBook.ValidateTitle()
                 AuthorsErrorText = model.NewBook.ValidateAuthors()
                 LinkErrorText = model.NewBook.ValidateLink() }
-        validated, 
+        validated,
             if model.NewBook.Validate() then
-                Cmd.ofMsg AddBook
+                Cmd.OfFunc.result AddBook
             else
                 Cmd.none
 

--- a/src/Client/paket.references
+++ b/src/Client/paket.references
@@ -7,4 +7,7 @@ Fable.Elmish.HMR
 Fable.Core
 Thoth.Json
 Thoth.Json.Net
-Fable.PowerPack
+Fable.Fetch
+Fable.Promise
+Fable.Browser.Dom
+Fable.Browser.WebStorage

--- a/src/Client/views/Menu.fs
+++ b/src/Client/views/Menu.fs
@@ -1,6 +1,6 @@
 module Client.Menu
 
-open Fable.Helpers.React
+open Fable.React
 open Client.Styles
 open Client.Pages
 open ServerCode.Domain

--- a/src/Server/paket.references
+++ b/src/Server/paket.references
@@ -12,7 +12,10 @@ Microsoft.AspNetCore.WebSockets.Server
 
 Fable.Core
 Fable.React
-Fable.Import.Browser
+Fable.Browser.Dom
+Fable.Browser.WebStorage
+Fable.Promise
+Fable.Fetch
 Fable.Elmish.Browser
 Fable.Elmish.React
 Thoth.Json.Net


### PR DESCRIPTION
@forki @alfonsogarciacaro I am trying to update the repo to use Fable 2.2 and Fable.Core v3.

For now, I have just updated the client side to Fable.Core v3 however I am stuck.

In order, to make paket resolve the packages I needed to add `framework: netstandard2.0` to `paket.dependencies` otherwise `Microsoft.NET.Sdk.Functions` complains about a conflict for the resolution of dependencies for `.Net Framework`.

But if I try to build the server, it's failing and find no dependency. I guess it's because of `framework: netstandard2.0` while the server is a `netcoreapp2.2` so I tried `framework: netcoreapp2.2,  netstandard2.0` without success.

Would you please be able to guide me on how to solve the situation or contribute to this PR?