### PR TITLE
Saving wishlist failed

### DIFF
--- a/src/Client/pages/WishList.fs
+++ b/src/Client/pages/WishList.fs
@@ -61,7 +61,7 @@ let getResetTime () =
 
 let postWishList (token,wishList:WishList) =
     promise {
-        let url = sprintf "/api/wishlist/%s" wishList.UserName
+        let url = "/api/wishlist/"
         let body = Encode.Auto.toString(0, wishList)
         let props =
             [ Method HttpMethod.POST

--- a/src/Server/WebServer.fs
+++ b/src/Server/WebServer.fs
@@ -14,7 +14,7 @@ let webApp databaseType =
 
     let secured = router {
         pipe_through (Saturn.Auth.requireAuthentication Saturn.ChallengeType.JWT)
-        post "/api/wishlist/%s" (WishList.postWishList db.SaveWishList)
+        post "/api/wishlist/" (WishList.postWishList db.SaveWishList)
     }
 
     router {


### PR DESCRIPTION
The posts for adding or removing books went to `/api/wishlist/{username}`, but resulted in 404 since `post "/api/wishlist/%s"` doesn't take format string parameters.

Since `WishList.postWishList` doesn't use user name from the URL parameter anyways, removing the user name feels the easiest fix.